### PR TITLE
Add platform-specific install instructions for Copilot CLI, VS Code, and Claude Code

### DIFF
--- a/.github/plugins/azure-skills/README.md
+++ b/.github/plugins/azure-skills/README.md
@@ -55,22 +55,16 @@ Before you install, make sure you have:
 
 ### GitHub Copilot CLI
 
-**Install the marketplace** (first time only):
-
-```
-/plugin marketplace add microsoft/azure-skills
-```
-
 **Install the plugin**:
 
 ```
-/plugin install microsoft/azure-skills
+/plugin install azure@awesome-copilot
 ```
 
 **Update the plugin**:
 
 ```
-/plugin update azure@azure-skills
+/plugin update azure@awesome-copilot
 ```
 
 ### VS Code

--- a/README.md
+++ b/README.md
@@ -55,22 +55,16 @@ Before you install, make sure you have:
 
 ### GitHub Copilot CLI
 
-**Install the marketplace** (first time only):
-
-```
-/plugin marketplace add microsoft/azure-skills
-```
-
 **Install the plugin**:
 
 ```
-/plugin install microsoft/azure-skills
+/plugin install azure@awesome-copilot
 ```
 
 **Update the plugin**:
 
 ```
-/plugin update azure@azure-skills
+/plugin update azure@awesome-copilot
 ```
 
 ### VS Code


### PR DESCRIPTION
Updates both READMEs (root and plugin) with platform-specific install instructions:

- **GitHub Copilot CLI**: marketplace add, plugin install, and plugin update commands
- **VS Code**: Link to Azure MCP extension + note about companion skills extension
- **Claude Code**: marketplace add, plugin install, and plugin update commands

Also syncs the plugin README to match the root README.