### PR TITLE
Add plugin.json for VS Code

### DIFF
--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "azure",
+  "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/github-copilot-for-azure",
+  "keywords": ["azure", "cloud", "infrastructure", "deployment", "microsoft", "devops"],
+  "skills": "../plugins/azure-skills/skills/",
+  "mcpServers": {
+    "azure": {
+      "command": "npx",
+      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+    },
+    "foundry-mcp": {
+      "type": "http",
+      "url": "https://mcp.ai.azure.com"
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+  }
+}


### PR DESCRIPTION
VS Code uses github/awesome-copilot as a default plugin marketplace, and github/awesome-copilot in turn points to the plugin in microsoft/azure-skills. However, VS Code doesn't currently support the `source` format we're using in the plugin entry, where we're pointing it at a GitHub repo _and_ specifying the plugin location in that repo. VS Code expects to find a single plugin with the plugin.json at a known location. So currently you can "install" the plugin in VS Code but nothing happens since it doesn't know where to look for the skills and MCP servers.

Here we copy .github\plugins\azure-skills\.claude-plugin\plugin.json to .github\plugin\plugin.json and make some minimal updates to keep it pointing to the skills in the correct location.