### PR TITLE
Try a symlink

### DIFF
--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -8,7 +8,6 @@
   },
   "homepage": "https://github.com/microsoft/github-copilot-for-azure",
   "keywords": ["azure", "cloud", "infrastructure", "deployment", "microsoft", "devops"],
-  "skills": "../plugins/azure-skills/skills/",
   "mcpServers": {
     "azure": {
       "command": "npx",
@@ -21,6 +20,6 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"]
-    },
+    }
   }
 }

--- a/.github/plugin/skills
+++ b/.github/plugin/skills
@@ -1,0 +1,1 @@
+D:/repos/azure-skills/.github/plugins/azure-skills/skills


### PR DESCRIPTION
Adding the .github/plugin/plugin.json file didn't work, and I suspect this is because the `skills` entry uses a relative path that would take you out of this directory and VS Code ends up ignoring it.

Here we replace this with a symlink to the actual folder under .github/plugins/azure-skills/.