### PR TITLE
Update Copilot CLI install instructions to use azure-skills marketplace

### DIFF
--- a/.github/plugins/azure-skills/README.md
+++ b/.github/plugins/azure-skills/README.md
@@ -55,16 +55,22 @@ Before you install, make sure you have:
 
 ### GitHub Copilot CLI
 
+**Add the marketplace** (first time only):
+
+```
+/plugin marketplace add microsoft/azure-skills
+```
+
 **Install the plugin**:
 
 ```
-/plugin install azure@awesome-copilot
+/plugin install azure@azure-skills
 ```
 
 **Update the plugin**:
 
 ```
-/plugin update azure@awesome-copilot
+/plugin update azure@azure-skills
 ```
 
 ### VS Code

--- a/README.md
+++ b/README.md
@@ -55,16 +55,22 @@ Before you install, make sure you have:
 
 ### GitHub Copilot CLI
 
+**Add the marketplace** (first time only):
+
+```
+/plugin marketplace add microsoft/azure-skills
+```
+
 **Install the plugin**:
 
 ```
-/plugin install azure@awesome-copilot
+/plugin install azure@azure-skills
 ```
 
 **Update the plugin**:
 
 ```
-/plugin update azure@awesome-copilot
+/plugin update azure@azure-skills
 ```
 
 ### VS Code


### PR DESCRIPTION
Updates the GitHub Copilot CLI install instructions in both README files to add a marketplace add step and change references from awesome-copilot to azure-skills.