### PR TITLE
Generate marketplace.json from apm.yml via 'apm pack'

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "azure",
-      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your coding agent harness.",
+      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your agent harness.",
       "source": "./.github/plugins/azure-skills",
       "homepage": "https://github.com/microsoft/azure-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "azure",
-      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
+      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your coding agent harness.",
       "source": "./.github/plugins/azure-skills",
       "homepage": "https://github.com/microsoft/azure-skills"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "azure",
-      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your agent harness.",
+      "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
       "source": "./.github/plugins/azure-skills",
       "homepage": "https://github.com/microsoft/azure-skills"
     }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Before you install, make sure you have:
 - **Azure CLI** installed and authenticated with `az login`
 - **Azure Developer CLI** installed and authenticated with `azd auth login` if you plan to use deployment workflows
 
+### APM (one install, multiple harnesses)
+
+The Azure Skills Plugin is multi-harness. If you use [APM](https://github.com/microsoft/apm), one command installs it across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini from a single `apm.yml`:
+
+```bash
+apm install microsoft/azure-skills
+```
+
 ### GitHub Copilot CLI
 
 **Add the marketplace** (first time only):
@@ -213,14 +221,6 @@ git --version
    - `-y` - Automatically accepts prompts during installation
 
 3. Wait for the installation to complete. You should see confirmation that the Azure skills have been successfully added.
-
-### APM (one install, multiple harnesses)
-
-The Azure Skills Plugin is multi-harness. If you use [APM](https://github.com/microsoft/apm), one command installs it across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini from a single `apm.yml`:
-
-```bash
-apm install microsoft/azure-skills
-```
 
 ## Sovereign Cloud Configuration
 

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ git --version
 
 3. Wait for the installation to complete. You should see confirmation that the Azure skills have been successfully added.
 
-### All of the above (APM)
+### APM (one install, multiple hosts)
 
-**Install once, use everywhere.** [APM](https://github.com/microsoft/apm) resolves azure-skills into GitHub Copilot, Copilot Cowork, Claude Code, Cursor, Codex, Gemini, and OpenCode from one `apm.yml`:
+The Azure Skills Plugin is multi-host. If you use [APM](https://github.com/microsoft/apm), one command installs it across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini from a single `apm.yml`:
 
 ```bash
 apm install microsoft/azure-skills

--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ git --version
 
 3. Wait for the installation to complete. You should see confirmation that the Azure skills have been successfully added.
 
-### APM (one install, multiple hosts)
+### APM (one install, multiple harnesses)
 
-The Azure Skills Plugin is multi-host. If you use [APM](https://github.com/microsoft/apm), one command installs it across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini from a single `apm.yml`:
+The Azure Skills Plugin is multi-harness. If you use [APM](https://github.com/microsoft/apm), one command installs it across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini from a single `apm.yml`:
 
 ```bash
 apm install microsoft/azure-skills

--- a/README.md
+++ b/README.md
@@ -214,6 +214,14 @@ git --version
 
 3. Wait for the installation to complete. You should see confirmation that the Azure skills have been successfully added.
 
+### All of the above (APM)
+
+**Install once, use everywhere.** [APM](https://github.com/microsoft/apm) resolves azure-skills into GitHub Copilot, Copilot Cowork, Claude Code, Cursor, Codex, Gemini, and OpenCode from one `apm.yml`:
+
+```bash
+apm install microsoft/azure-skills
+```
+
 ## Sovereign Cloud Configuration
 
 By default, the Azure MCP server connects to the Azure Public Cloud. If you use a sovereign cloud (Azure China Cloud or Azure US Government), you need to configure the MCP server to use the appropriate cloud environment.

--- a/apm.yml
+++ b/apm.yml
@@ -1,3 +1,15 @@
 name: azure-skills
 version: 1.0.0
 description: Microsoft Azure MCP and Skills integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your development environment.
+
+# Marketplace authoring: source of truth for .claude-plugin/marketplace.json.
+# Regenerate the JSON with `apm pack` (https://github.com/microsoft/apm).
+marketplace:
+  owner:
+    name: Microsoft
+    url: https://www.microsoft.com
+  packages:
+    - name: azure
+      description: Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.
+      source: ./.github/plugins/azure-skills
+      homepage: https://github.com/microsoft/azure-skills

--- a/apm.yml
+++ b/apm.yml
@@ -10,6 +10,6 @@ marketplace:
     url: https://www.microsoft.com
   packages:
     - name: azure
-      description: Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your coding agent harness.
+      description: Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your agent harness.
       source: ./.github/plugins/azure-skills
       homepage: https://github.com/microsoft/azure-skills

--- a/apm.yml
+++ b/apm.yml
@@ -10,6 +10,6 @@ marketplace:
     url: https://www.microsoft.com
   packages:
     - name: azure
-      description: Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.
+      description: Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from your coding agent harness.
       source: ./.github/plugins/azure-skills
       homepage: https://github.com/microsoft/azure-skills


### PR DESCRIPTION
> [!NOTE]
> Drafted as a humble follow-up to #100 — happy to close if you already have an internal generator.

## TL;DR

The Azure Skills Plugin is already positioned in the README as a **multi-harness** capability layer (Copilot CLI, VS Code, Claude Code, and other compatible harnesses). This PR makes that explicit for users on the [APM](https://github.com/microsoft/apm) ecosystem and lets `apm.yml` author the existing `.claude-plugin/marketplace.json` via [`apm pack`](https://microsoft.github.io/apm/reference/cli-commands/#apm-pack---pack-distributable-artifacts).

Three small changes:

1. **`apm.yml`** — adds a `marketplace:` block mirroring today's `marketplace.json`, with the per-package description generalized from "directly from Claude Code" to "directly from your agent harness" (since the plugin is consumed across multiple harnesses).
2. **`.claude-plugin/marketplace.json`** — regenerated from `apm.yml` with `apm pack`. The only diff vs. `main` is the description wording change above.
3. **`README.md`** — adds an "APM (one install, multiple harnesses)" section under "Install in 60 seconds", giving users one command to install azure-skills across GitHub Copilot, Claude Code, Cursor, OpenCode, Codex, and Gemini.

## Why

This repo already carries [`apm.yml`](https://github.com/microsoft/azure-skills/blob/main/apm.yml) (3 lines today) and [`.claude-plugin/marketplace.json`](https://github.com/microsoft/azure-skills/blob/main/.claude-plugin/marketplace.json) (hand-authored). I couldn't find a workflow keeping them in sync, so I'm guessing the JSON gets edited manually on every plugin/release change. If that's right, this PR makes:

- `apm.yml` the single source of truth (plugin name/version inherit top-level fields when omitted)
- `marketplace.json` a regenerated artifact (`apm pack` — one command, deterministic, ASCII-only)
- Drift a one-line CI check: `apm pack && git diff --exit-code .claude-plugin/marketplace.json`

It also reinforces the multi-harness story already in the README: one `apm.yml` resolves the same plugin across the harnesses APM supports, so users on Cursor, Codex, Gemini, OpenCode, etc. get a one-command path alongside the existing Copilot CLI and VS Code instructions. The package description follows: "directly from Claude Code" → "directly from your agent harness".

If you already have an internal generator I missed, just close the PR — no offence taken. See #100 for the question version.

## What changed

| File | Change |
|---|---|
| `apm.yml` | Add a `marketplace:` block with the per-package description generalized to "directly from your agent harness". |
| `.claude-plugin/marketplace.json` | Regenerated from `apm.yml` via `apm pack`. Only diff vs. `main` is the same description wording change. |
| `README.md` | Add a short "APM (one install, multiple harnesses)" section under "Install in 60 seconds", consistent with the README's existing multi-harness framing. |

## How

```yaml
# apm.yml
name: azure-skills
version: 1.0.0
description: Microsoft Azure MCP and Skills integration ...

marketplace:
  owner:
    name: Microsoft
    url: https://www.microsoft.com
  packages:
    - name: azure
      description: Microsoft Azure MCP integration ... directly from your agent harness.
      source: ./.github/plugins/azure-skills
      homepage: https://github.com/microsoft/azure-skills
```

Run:
```bash
apm pack
# -> writes .claude-plugin/marketplace.json
```

## How to test

```bash
# Install APM CLI (>= 0.11.0)
curl -sSL https://raw.githubusercontent.com/microsoft/apm/main/install.sh | sh

# Then from this branch:
git checkout apm-pack-marketplace
apm pack
git diff --exit-code .claude-plugin/marketplace.json   # should be empty
```

## Trade-offs

- **APM CLI dependency for regeneration.** Hand-editing `marketplace.json` still works; this only affects maintainers who choose to use `apm pack`. End users on any supported harness are unaffected.
- **Two files describe the marketplace until the JSON is marked as generated.** Intentionally left out of this PR to keep the change reviewable; can follow up if useful.
- **No CI workflow added in this PR.** A 5-line GitHub Actions step to assert `apm pack && git diff --exit-code .claude-plugin/marketplace.json` is a natural follow-up if the PR lands — and [`microsoft/apm-action`](https://github.com/microsoft/apm-action) (`uses: microsoft/apm-action@v1`) already wraps the CLI for that purpose, so the drift check ends up being one step, not a custom shell block. Out of scope here — just flagging the path.

## Related

- Question issue: #100
- APM CLI: https://github.com/microsoft/apm
- `apm pack` reference: https://microsoft.github.io/apm/reference/cli-commands/#apm-pack---pack-distributable-artifacts

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
