### PR TITLE
Quote ${CLAUDE_PLUGIN_ROOT} in azure-skills PostToolUse hook to fix Windows paths with spaces

### DIFF
--- a/.github/plugins/azure-skills/hooks/hooks.json
+++ b/.github/plugins/azure-skills/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh\""
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Problem

`hooks/hooks.json` registers the PostToolUse hook as:

```json
"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"
```

`${CLAUDE_PLUGIN_ROOT}` is expanded by the shell without quoting. When the resolved plugin path contains a space — which is common on Windows, where the user profile typically lives under `C:\Users\<First Last>\` — the shell word-splits the command and `bash` is invoked with a truncated argv[1].

Real-world failure observed on Windows 11 (user `Sutad Kunapirakkul`, Claude Code v2 with azure plugin v1.1.46 enabled):

```
PostToolUse:Write hook error    bash: /c/Users/Sutad: No such file or directory
PostToolUse:Read  hook error    bash: /c/Users/Sutad: No such file or directory
PostToolUse:Edit  hook error    bash: /c/Users/Sutad: No such file or directory
```

The hook has no `matcher`, so it fires for every tool call and the error repeats throughout the session — telemetry never runs, and the transcript fills with noise.

## Fix

Wrap `${CLAUDE_PLUGIN_ROOT}` in double quotes so the expanded path is passed as a single argument to `bash`. This is the same convention used in other plugins (`ralph-loop`, `explanatory-output-style`, `learning-output-style` in the official Claude plugins marketplace).

The mirrored copy at `.github/plugins/azure-skills/hooks/hooks.json` is updated identically so the next sync from `GitHub-Copilot-for-Azure` does not regress this fix. (If the canonical source lives upstream, please cherry-pick the same one-line change there.)

## Test plan

- [x] Confirmed `bash "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh"` executes successfully when `CLAUDE_PLUGIN_ROOT=C:\Users\Sutad Kunapirakkul\.claude\plugins\cache\claude-plugins-official\azure\1.1.46` and returns the expected `{"continue":true}` payload.
- [x] Diff is minimal: one line per file, two files total.
- [x] No behavioral change on paths without spaces (already covered by existing usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)