### PR TITLE
Keep registry URLs out of the landing page lockfile

### DIFF
--- a/landing-page/.npmrc
+++ b/landing-page/.npmrc
@@ -1,1 +1,2 @@
 registry=https://packagefeedproxy.microsoft.io/npm/
+omit-lockfile-registry-resolved=true

--- a/landing-page/package-lock.json
+++ b/landing-page/package-lock.json
@@ -25,7 +25,6 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha1-e/aLIMCjUPk2kV/K4G9Y4yAHzjA=",
       "dev": true,
       "license": "MIT",
@@ -38,7 +37,6 @@
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
       "integrity": "sha1-ePoDa+GmCBtad6XPWfUMd1K2uiY=",
       "dev": true,
       "license": "MIT",
@@ -52,7 +50,6 @@
     },
     "node_modules/@antfu/utils": {
       "version": "8.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@antfu/utils/-/utils-8.1.1.tgz",
       "integrity": "sha1-lbGUfSkqmi7/+6IIF5bcqgXs7fs=",
       "dev": true,
       "license": "MIT",
@@ -62,7 +59,6 @@
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/check/-/check-0.9.10.tgz",
       "integrity": "sha1-dllc256pkOFVv1vmlaZeyz7OM00=",
       "dev": true,
       "license": "MIT",
@@ -81,14 +77,12 @@
     },
     "node_modules/@astrojs/compiler": {
       "version": "2.13.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler/-/compiler-2.13.1.tgz",
       "integrity": "sha1-088m7ZjhnT0QDNvrZhznuFZxnKc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@astrojs/compiler-binding": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding/-/compiler-binding-0.3.2.tgz",
       "integrity": "sha1-hnDIKUSk2xf8NX8FuKqiQddIfLA=",
       "dev": true,
       "license": "MIT",
@@ -109,7 +103,6 @@
     },
     "node_modules/@astrojs/compiler-binding-darwin-arm64": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.2.tgz",
       "integrity": "sha1-5XZWZ4zmpUyg66GiI6fdLehNkUA=",
       "cpu": [
         "arm64"
@@ -126,7 +119,6 @@
     },
     "node_modules/@astrojs/compiler-binding-darwin-x64": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.2.tgz",
       "integrity": "sha1-Aw7sVhaXUjrZa+83RJuo7P94RWw=",
       "cpu": [
         "x64"
@@ -143,7 +135,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.2.tgz",
       "integrity": "sha1-hjWPGxTnHECkFTpCaAF7wCYuhzY=",
       "cpu": [
         "arm64"
@@ -160,7 +151,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.2.tgz",
       "integrity": "sha1-zo83TLzOS2vbOVCgAngxvLGgtG0=",
       "cpu": [
         "arm64"
@@ -177,7 +167,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.2.tgz",
       "integrity": "sha1-Cl/Up6PT3Vj9qv0KpTnyFRqj9Zs=",
       "cpu": [
         "x64"
@@ -194,7 +183,6 @@
     },
     "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.2.tgz",
       "integrity": "sha1-yZNQ/tw5GYCHCBwhRRE+arkkvmE=",
       "cpu": [
         "x64"
@@ -211,7 +199,6 @@
     },
     "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.2.tgz",
       "integrity": "sha1-tprquJiw2x6blGK9zIZh6baD8L8=",
       "cpu": [
         "wasm32"
@@ -228,7 +215,6 @@
     },
     "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.2.tgz",
       "integrity": "sha1-sqnC1I8xFWetZUdygCLXZ7o72nw=",
       "cpu": [
         "arm64"
@@ -245,7 +231,6 @@
     },
     "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.2.tgz",
       "integrity": "sha1-JtBeSJeMRIt7qBz38PR+SoXVIaI=",
       "cpu": [
         "x64"
@@ -262,7 +247,6 @@
     },
     "node_modules/@astrojs/compiler-rs": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/compiler-rs/-/compiler-rs-0.3.2.tgz",
       "integrity": "sha1-SlZnBYKEX7IdvegWBVjfAL2SbKg=",
       "dev": true,
       "license": "MIT",
@@ -275,7 +259,6 @@
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.10.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/internal-helpers/-/internal-helpers-0.10.2.tgz",
       "integrity": "sha1-XhWbDiabiBLdsagdZJ1xTdXs6Z4=",
       "dev": true,
       "license": "MIT",
@@ -292,7 +275,6 @@
     },
     "node_modules/@astrojs/language-server": {
       "version": "2.16.13",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/language-server/-/language-server-2.16.13.tgz",
       "integrity": "sha1-oCkAGrVifjyI1Mf+Wnb4SGmuxek=",
       "dev": true,
       "license": "MIT",
@@ -334,7 +316,6 @@
     },
     "node_modules/@astrojs/markdown-satteri": {
       "version": "0.3.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/markdown-satteri/-/markdown-satteri-0.3.5.tgz",
       "integrity": "sha1-fXMAIQZZLGxqV6rbm8jQARam+6I=",
       "dev": true,
       "license": "MIT",
@@ -348,7 +329,6 @@
     },
     "node_modules/@astrojs/prism": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/prism/-/prism-4.0.2.tgz",
       "integrity": "sha1-XcByWmHqb+ZlpIR05lyWgHmlH0A=",
       "dev": true,
       "license": "MIT",
@@ -361,7 +341,6 @@
     },
     "node_modules/@astrojs/telemetry": {
       "version": "3.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/telemetry/-/telemetry-3.3.3.tgz",
       "integrity": "sha1-JOW88gPRrAd0fALj8HEBNycggrg=",
       "dev": true,
       "license": "MIT",
@@ -377,7 +356,6 @@
     },
     "node_modules/@astrojs/yaml2ts": {
       "version": "0.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
       "integrity": "sha1-iZ6N552mFFtRTY+3wXVFJvj211E=",
       "dev": true,
       "license": "MIT",
@@ -387,7 +365,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha1-fwhx2Zgk0jE31g+G/PYTD9WhtR8=",
       "dev": true,
       "license": "MIT",
@@ -397,7 +374,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "dev": true,
       "license": "MIT",
@@ -407,7 +383,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha1-g3uHOHy/XsVTDLY0s8Yi9o7bkzQ=",
       "dev": true,
       "license": "MIT",
@@ -423,7 +398,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha1-gAXjHYJxLuetrvbiPGO3GmJ3CpI=",
       "dev": true,
       "license": "MIT",
@@ -437,7 +411,6 @@
     },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
       "integrity": "sha1-pcWWW56qHQao6pJP2bSrAY9LVnM=",
       "cpu": [
         "arm64"
@@ -451,7 +424,6 @@
     },
     "node_modules/@bruits/satteri-darwin-x64": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
       "integrity": "sha1-O89jnHPIOCin43q7+AGfan65/lg=",
       "cpu": [
         "x64"
@@ -465,7 +437,6 @@
     },
     "node_modules/@bruits/satteri-linux-arm64-gnu": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
       "integrity": "sha1-CF3WnAH5+J9kE9gC0BjjBHFLlXI=",
       "cpu": [
         "arm64"
@@ -479,7 +450,6 @@
     },
     "node_modules/@bruits/satteri-linux-arm64-musl": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
       "integrity": "sha1-Yts0XlGnqK7CBKDzbzjctb03rp0=",
       "cpu": [
         "arm64"
@@ -493,7 +463,6 @@
     },
     "node_modules/@bruits/satteri-linux-x64-gnu": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
       "integrity": "sha1-Quq2YdUoEBC48gO+X+r8/TppUgQ=",
       "cpu": [
         "x64"
@@ -507,7 +476,6 @@
     },
     "node_modules/@bruits/satteri-linux-x64-musl": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
       "integrity": "sha1-UOdkjpOU+bYsfWQwJO8GppodZFI=",
       "cpu": [
         "x64"
@@ -521,7 +489,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
       "integrity": "sha1-zST/vhZQV35ivtes0hxItMXrrR0=",
       "cpu": [
         "wasm32"
@@ -540,7 +507,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -552,7 +518,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -563,7 +528,6 @@
     },
     "node_modules/@bruits/satteri-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -574,7 +538,6 @@
     },
     "node_modules/@bruits/satteri-win32-arm64-msvc": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
       "integrity": "sha1-DYOFJTX2PFCrkCU/4gnlzlz/6wk=",
       "cpu": [
         "arm64"
@@ -588,7 +551,6 @@
     },
     "node_modules/@bruits/satteri-win32-x64-msvc": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
       "integrity": "sha1-FUinVztYRp3GM+zDhArqwZSJNxA=",
       "cpu": [
         "x64"
@@ -602,7 +564,6 @@
     },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@capsizecss/unpack/-/unpack-4.0.1.tgz",
       "integrity": "sha1-X8Xzo3GpOmnXZOgaCbrfAUM4Fzk=",
       "dev": true,
       "license": "MIT",
@@ -615,7 +576,6 @@
     },
     "node_modules/@clack/core": {
       "version": "1.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@clack/core/-/core-1.4.3.tgz",
       "integrity": "sha1-HoMZdPgR1zNwfsZQ5Y9pDX10xfo=",
       "dev": true,
       "license": "MIT",
@@ -629,7 +589,6 @@
     },
     "node_modules/@clack/prompts": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@clack/prompts/-/prompts-1.7.0.tgz",
       "integrity": "sha1-LWztNjpgi6I/a5YRIFuDBshbvw0=",
       "dev": true,
       "license": "MIT",
@@ -645,7 +604,6 @@
     },
     "node_modules/@ctrl/tinycolor": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
       "integrity": "sha1-ul0LkXMDwLPTwUxIZc3G3tJawF8=",
       "dev": true,
       "license": "MIT",
@@ -655,7 +613,6 @@
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
       "integrity": "sha1-7SuI/je5ciktYCbHxUCq+IfOy24=",
       "dev": true,
       "license": "MIT",
@@ -665,7 +622,6 @@
     },
     "node_modules/@emmetio/css-abbreviation": {
       "version": "2.1.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
       "integrity": "sha1-t4UxNIbrpst+tiOtOTeMThBj3AA=",
       "dev": true,
       "license": "MIT",
@@ -675,7 +631,6 @@
     },
     "node_modules/@emmetio/css-parser": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
       "integrity": "sha1-DSl1uR26WGEuXDXjaogO9CQGfsM=",
       "dev": true,
       "license": "MIT",
@@ -686,7 +641,6 @@
     },
     "node_modules/@emmetio/html-matcher": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
       "integrity": "sha1-Q7enG5HNxRHLaZy+nGe7XUyrZ1Q=",
       "dev": true,
       "license": "ISC",
@@ -696,28 +650,24 @@
     },
     "node_modules/@emmetio/scanner": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/scanner/-/scanner-1.0.4.tgz",
       "integrity": "sha1-6c3GcZT9kfi36xQQFL5PLQhsFfE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
       "integrity": "sha1-Rs/+oRmgoAMxKiHC2bVijLX81EI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emmetio/stream-reader-utils": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
       "integrity": "sha1-JEywLHfsLnT3ipvTGCGKvJxQCmE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "2.0.0-alpha.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
       "integrity": "sha1-BJrOZx8wJ01qTRYdO3cROLhi9wQ=",
       "dev": true,
       "license": "MIT",
@@ -729,7 +679,6 @@
     },
     "node_modules/@emnapi/runtime": {
       "version": "2.0.0-alpha.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
       "integrity": "sha1-rvBMNcmoPCOrDyUfAwlUQO3XrV8=",
       "dev": true,
       "license": "MIT",
@@ -740,7 +689,6 @@
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
       "integrity": "sha1-HJKRkyi+H2q3n7YKZ8zz0uYs1Is=",
       "dev": true,
       "license": "MIT",
@@ -751,7 +699,6 @@
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
       "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
       "cpu": [
         "ppc64"
@@ -768,7 +715,6 @@
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
       "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
       "cpu": [
         "arm"
@@ -785,7 +731,6 @@
     },
     "node_modules/@esbuild/android-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
       "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
       "cpu": [
         "arm64"
@@ -802,7 +747,6 @@
     },
     "node_modules/@esbuild/android-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
       "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
       "cpu": [
         "x64"
@@ -819,7 +763,6 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
       "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
       "cpu": [
         "arm64"
@@ -836,7 +779,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
       "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
       "cpu": [
         "x64"
@@ -853,7 +795,6 @@
     },
     "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
       "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
       "cpu": [
         "arm64"
@@ -870,7 +811,6 @@
     },
     "node_modules/@esbuild/freebsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
       "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
       "cpu": [
         "x64"
@@ -887,7 +827,6 @@
     },
     "node_modules/@esbuild/linux-arm": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
       "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
       "cpu": [
         "arm"
@@ -904,7 +843,6 @@
     },
     "node_modules/@esbuild/linux-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
       "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
       "cpu": [
         "arm64"
@@ -921,7 +859,6 @@
     },
     "node_modules/@esbuild/linux-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
       "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
       "cpu": [
         "ia32"
@@ -938,7 +875,6 @@
     },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
       "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
       "cpu": [
         "loong64"
@@ -955,7 +891,6 @@
     },
     "node_modules/@esbuild/linux-mips64el": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
       "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
       "cpu": [
         "mips64el"
@@ -972,7 +907,6 @@
     },
     "node_modules/@esbuild/linux-ppc64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
       "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
       "cpu": [
         "ppc64"
@@ -989,7 +923,6 @@
     },
     "node_modules/@esbuild/linux-riscv64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
       "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
       "cpu": [
         "riscv64"
@@ -1006,7 +939,6 @@
     },
     "node_modules/@esbuild/linux-s390x": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
       "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
       "cpu": [
         "s390x"
@@ -1023,7 +955,6 @@
     },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
       "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
       "cpu": [
         "x64"
@@ -1040,7 +971,6 @@
     },
     "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
       "cpu": [
         "arm64"
@@ -1057,7 +987,6 @@
     },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
       "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
       "cpu": [
         "x64"
@@ -1074,7 +1003,6 @@
     },
     "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
       "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
       "cpu": [
         "arm64"
@@ -1091,7 +1019,6 @@
     },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
       "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
       "cpu": [
         "x64"
@@ -1108,7 +1035,6 @@
     },
     "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
       "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
       "cpu": [
         "arm64"
@@ -1125,7 +1051,6 @@
     },
     "node_modules/@esbuild/sunos-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
       "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
       "cpu": [
         "x64"
@@ -1142,7 +1067,6 @@
     },
     "node_modules/@esbuild/win32-arm64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
       "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
       "cpu": [
         "arm64"
@@ -1159,7 +1083,6 @@
     },
     "node_modules/@esbuild/win32-ia32": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
       "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
       "cpu": [
         "ia32"
@@ -1176,7 +1099,6 @@
     },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
       "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
       "cpu": [
         "x64"
@@ -1193,7 +1115,6 @@
     },
     "node_modules/@expressive-code/core": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/core/-/core-0.44.1.tgz",
       "integrity": "sha1-f0K9tpME4GoxR6GoA5xwXuSOsvs=",
       "dev": true,
       "license": "MIT",
@@ -1211,7 +1132,6 @@
     },
     "node_modules/@expressive-code/plugin-frames": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-frames/-/plugin-frames-0.44.1.tgz",
       "integrity": "sha1-ZBYWl09zUuE1cmQGPIwhHzmyhDk=",
       "dev": true,
       "license": "MIT",
@@ -1221,7 +1141,6 @@
     },
     "node_modules/@expressive-code/plugin-shiki": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-shiki/-/plugin-shiki-0.44.1.tgz",
       "integrity": "sha1-zsr85/Ob5h0UfLel/VAD+obj54g=",
       "dev": true,
       "license": "MIT",
@@ -1232,7 +1151,6 @@
     },
     "node_modules/@expressive-code/plugin-text-markers": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@expressive-code/plugin-text-markers/-/plugin-text-markers-0.44.1.tgz",
       "integrity": "sha1-fRMq5v7NKhAu40xR9uP/XUnoOwg=",
       "dev": true,
       "license": "MIT",
@@ -1242,7 +1160,6 @@
     },
     "node_modules/@iconify-json/lucide": {
       "version": "1.2.120",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify-json/lucide/-/lucide-1.2.120.tgz",
       "integrity": "sha1-C6FjjUxf424QJEPB4mYPBk6pqAg=",
       "dev": true,
       "license": "ISC",
@@ -1252,7 +1169,6 @@
     },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.92",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify-json/simple-icons/-/simple-icons-1.2.92.tgz",
       "integrity": "sha1-4FWWi96p+XqH2Vds6sGmyFNm1jY=",
       "dev": true,
       "license": "CC0-1.0",
@@ -1262,7 +1178,6 @@
     },
     "node_modules/@iconify/tools": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify/tools/-/tools-4.2.0.tgz",
       "integrity": "sha1-rp6+TYBsLmr5WuJJyFXCZlATSI8=",
       "dev": true,
       "license": "MIT",
@@ -1280,7 +1195,6 @@
     },
     "node_modules/@iconify/tools/node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-7.2.0.tgz",
       "integrity": "sha1-o2y1fQtQHOEI5NIFWaFQo5HZerc=",
       "dev": true,
       "license": "MIT",
@@ -1290,7 +1204,6 @@
     },
     "node_modules/@iconify/tools/node_modules/css-tree": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-2.3.1.tgz",
       "integrity": "sha1-ECZM4eVELoVy/IL75JBkT/VLXCA=",
       "dev": true,
       "license": "MIT",
@@ -1304,14 +1217,12 @@
     },
     "node_modules/@iconify/tools/node_modules/mdn-data": {
       "version": "2.0.30",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha1-zk32+Ar2z74hjs1cVSuhPE36CMw=",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/@iconify/tools/node_modules/svgo": {
       "version": "3.3.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/svgo/-/svgo-3.3.4.tgz",
       "integrity": "sha1-/SqhD/WFs70rg842AvVYK8Bxi7U=",
       "dev": true,
       "license": "MIT",
@@ -1337,14 +1248,12 @@
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify/types/-/types-2.0.0.tgz",
       "integrity": "sha1-qw6epoHWyKEhTzDNdB/jogzFf1c=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@iconify/utils/-/utils-2.3.0.tgz",
       "integrity": "sha1-G7v4xHfr6afKyup4sbfok3+cv7o=",
       "dev": true,
       "license": "MIT",
@@ -1361,7 +1270,6 @@
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha1-sMLC+mYa33Xv/WtJZEl82AAQu50=",
       "dev": true,
       "license": "MIT",
@@ -1372,7 +1280,6 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
       "integrity": "sha1-iydAiEvFixJ/wwIEeaASlPoQlcs=",
       "cpu": [
         "arm64"
@@ -1395,7 +1302,6 @@
     },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
       "integrity": "sha1-kt+RMg+vV8xUszEYV3DVqT1RAEk=",
       "cpu": [
         "x64"
@@ -1418,7 +1324,6 @@
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
       "integrity": "sha1-SAGME3mo9QfWgdbNjb5D2XldyAk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -1438,7 +1343,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
       "integrity": "sha1-IntB/8bJlhK86rpW+ZShkz13lXM=",
       "cpu": [
         "arm64"
@@ -1455,7 +1359,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
       "integrity": "sha1-aUkD7EEMAJRc5bDCbayD1xhMi4Y=",
       "cpu": [
         "x64"
@@ -1472,7 +1375,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
       "integrity": "sha1-5g4IjIBr3hrCi+ZItgw0ZfQcGKc=",
       "cpu": [
         "arm"
@@ -1489,7 +1391,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
       "integrity": "sha1-Sd3xVnKGZqId7tBxbzu3K7NRF54=",
       "cpu": [
         "arm64"
@@ -1506,7 +1407,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
       "integrity": "sha1-vjFhqv1llBez4mN037vNLaK/tiw=",
       "cpu": [
         "ppc64"
@@ -1523,7 +1423,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
       "integrity": "sha1-vwCKZ3nZvitWpN9nt1OUH3Z8lX0=",
       "cpu": [
         "riscv64"
@@ -1540,7 +1439,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
       "integrity": "sha1-lYOBS421iInIW62eXgt4JSV/85Q=",
       "cpu": [
         "s390x"
@@ -1557,7 +1455,6 @@
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
       "integrity": "sha1-q8mjEUSVtwW6ILfBVoue7NYq67s=",
       "cpu": [
         "x64"
@@ -1574,7 +1471,6 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
       "integrity": "sha1-5Y+xSnh58V2ecKmChw84TzmoMqI=",
       "cpu": [
         "arm64"
@@ -1591,7 +1487,6 @@
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.3.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
       "integrity": "sha1-VhFID8t0Zd1TFgRNtTrXqEPtSvg=",
       "cpu": [
         "x64"
@@ -1608,7 +1503,6 @@
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
       "integrity": "sha1-yNpQDEAWiTqJ1G6YMtCKBu73fyc=",
       "cpu": [
         "arm"
@@ -1631,7 +1525,6 @@
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
       "integrity": "sha1-RLZYI+zJd9RYWzCAcP/zlHJW3gQ=",
       "cpu": [
         "arm64"
@@ -1654,7 +1547,6 @@
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
       "integrity": "sha1-6h19uBj1KvHh4FfoLVXyOy3jhkw=",
       "cpu": [
         "ppc64"
@@ -1677,7 +1569,6 @@
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
       "integrity": "sha1-civXmUZYeRsC0QN+oJyly3gDDY0=",
       "cpu": [
         "riscv64"
@@ -1700,7 +1591,6 @@
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
       "integrity": "sha1-6ClIF9faSVVBpKhw9W5rXQ+GQ80=",
       "cpu": [
         "s390x"
@@ -1723,7 +1613,6 @@
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
       "integrity": "sha1-mEPDLzmurEtg3WD540FlIKTk3kY=",
       "cpu": [
         "x64"
@@ -1746,7 +1635,6 @@
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
       "integrity": "sha1-nP7k7MPUGrmidOAZ3+e0BihAUQw=",
       "cpu": [
         "arm64"
@@ -1769,7 +1657,6 @@
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
       "integrity": "sha1-IE0GeMjDsVMA2aJuy5wNzaEcpd4=",
       "cpu": [
         "x64"
@@ -1792,7 +1679,6 @@
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
       "integrity": "sha1-QviXm9vhpUGi6bmdO1vgfmtxx8A=",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
@@ -1809,7 +1695,6 @@
     },
     "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
       "version": "1.11.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.3.tgz",
       "integrity": "sha1-hCV647BTHrKuwf+iPXBwDaAHupU=",
       "dev": true,
       "license": "MIT",
@@ -1820,7 +1705,6 @@
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
       "integrity": "sha1-gjqqk9FNuEmZ1bXcln/1bPGWbZ8=",
       "cpu": [
         "wasm32"
@@ -1840,7 +1724,6 @@
     },
     "node_modules/@img/sharp-win32-arm64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
       "integrity": "sha1-81VNRcviRTKgrepzbsV2WPdKKRE=",
       "cpu": [
         "arm64"
@@ -1860,7 +1743,6 @@
     },
     "node_modules/@img/sharp-win32-ia32": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
       "integrity": "sha1-CUKyZDvLV+SEGf5BGd6EB4rgrHQ=",
       "cpu": [
         "ia32"
@@ -1880,7 +1762,6 @@
     },
     "node_modules/@img/sharp-win32-x64": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
       "integrity": "sha1-iiXKzcdajCYHfAf7pR6AVqrkdPE=",
       "cpu": [
         "x64"
@@ -1900,7 +1781,6 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha1-LVmuOrSzj7QnC/oj0w+OLobH/jI=",
       "dev": true,
       "license": "ISC",
@@ -1913,7 +1793,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha1-Y0Khn0Q0dRjJPkOxrGnes8Rlah8=",
       "dev": true,
       "license": "MIT",
@@ -1924,7 +1803,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha1-N1xHbRlylHhRuh4Vro8SMEdEWqE=",
       "dev": true,
       "license": "MIT",
@@ -1935,7 +1813,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
       "dev": true,
       "license": "MIT",
@@ -1945,14 +1822,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha1-aRKwDSxjHA0Vzhp6tXzWV/Ko+Lo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha1-2xXWeByTHzolGj2sOVAcmKYIL9A=",
       "dev": true,
       "license": "MIT",
@@ -1963,7 +1838,6 @@
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
       "integrity": "sha1-16o5iEXjqxycj4HqUPUn7TfRZxU=",
       "dev": true,
       "license": "MIT",
@@ -1985,14 +1859,12 @@
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha1-VfPZpZdDCgHype9jxrQvdp+c404=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.139.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha1-ONdrnb+TTCoCvhdPsyzuvxgv50I=",
       "dev": true,
       "license": "MIT",
@@ -2002,7 +1874,6 @@
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
       "integrity": "sha1-9Yy5oKgSjtBYIoJyBShUf8XANfM=",
       "cpu": [
         "arm64"
@@ -2019,7 +1890,6 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
       "integrity": "sha1-RBFEwFpKgxqnUmmrw6SjJDdOpwc=",
       "cpu": [
         "arm64"
@@ -2036,7 +1906,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
       "integrity": "sha1-yC4wZSzvUsSvkl1cZsiVWkAxmBY=",
       "cpu": [
         "x64"
@@ -2053,7 +1922,6 @@
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
       "integrity": "sha1-wy6c5/ocD7K4CROio6BcPpB9BrA=",
       "cpu": [
         "x64"
@@ -2070,7 +1938,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
       "integrity": "sha1-zpC14iMWretQLqAQWC9JjNBgTyc=",
       "cpu": [
         "arm"
@@ -2087,7 +1954,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
       "integrity": "sha1-kZRxEMTdqk7vsATlJogHCXcIUgE=",
       "cpu": [
         "arm64"
@@ -2104,7 +1970,6 @@
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
       "integrity": "sha1-6zKy1BCMHHArkejN6KBD6uXKqU0=",
       "cpu": [
         "arm64"
@@ -2121,7 +1986,6 @@
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
       "integrity": "sha1-zLlDwR5acmVcuwL8EWNUHOtkB4I=",
       "cpu": [
         "ppc64"
@@ -2138,7 +2002,6 @@
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
       "integrity": "sha1-ozcx7lZ+kLdfrG5eVTB+iiswOPA=",
       "cpu": [
         "s390x"
@@ -2155,7 +2018,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
       "integrity": "sha1-p0wBqqzt/BHDm2/rozpfoMZUlJ8=",
       "cpu": [
         "x64"
@@ -2172,7 +2034,6 @@
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
       "integrity": "sha1-KM0XhJT6HmXbpBIim1zlXE3Vy9E=",
       "cpu": [
         "x64"
@@ -2189,7 +2050,6 @@
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
       "integrity": "sha1-98dfqRP8IIhNJqfUiNT1xZfNccA=",
       "cpu": [
         "arm64"
@@ -2206,7 +2066,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
       "integrity": "sha1-w3lYGUd4cIHfNj6hBhQPzV/sJS0=",
       "cpu": [
         "wasm32"
@@ -2225,7 +2084,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha1-ueEGTzprFjHiQeY460jXNr/TcqY=",
       "dev": true,
       "license": "MIT",
@@ -2237,7 +2095,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.11.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha1-WPHz1dgamxL3k6tojJY3GQECfCQ=",
       "dev": true,
       "license": "MIT",
@@ -2248,7 +2105,6 @@
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha1-TJO+z1v6OxPRu9zAau44MhrYE5o=",
       "dev": true,
       "license": "MIT",
@@ -2259,7 +2115,6 @@
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
       "integrity": "sha1-8jyIaU96cpoS85UCSu4434Cha6M=",
       "cpu": [
         "arm64"
@@ -2276,7 +2131,6 @@
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
       "integrity": "sha1-M3fI3g5WqIV/ESF1YRRwkOh0y0Y=",
       "cpu": [
         "x64"
@@ -2293,14 +2147,12 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha1-4/zuCT+7XOdl4a0Ij/TeKIn2+b4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
       "integrity": "sha1-rCOinO0CRwYKIQgV/KOcF95NLyY=",
       "dev": true,
       "license": "MIT",
@@ -2323,7 +2175,6 @@
     },
     "node_modules/@shikijs/core": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/core/-/core-4.3.1.tgz",
       "integrity": "sha1-0eS2f3R9VHF3UZ73aLBjbJfO3V0=",
       "dev": true,
       "license": "MIT",
@@ -2340,7 +2191,6 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
       "integrity": "sha1-ToY9sQazYVFIo628yxBFtonPyrA=",
       "dev": true,
       "license": "MIT",
@@ -2355,7 +2205,6 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
       "integrity": "sha1-z9XD+a21g1VFFV/f3AU9nR5cVWU=",
       "dev": true,
       "license": "MIT",
@@ -2369,7 +2218,6 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/langs/-/langs-4.3.1.tgz",
       "integrity": "sha1-mR6zILljDB/LXLVh7HsisCzbXoU=",
       "dev": true,
       "license": "MIT",
@@ -2382,7 +2230,6 @@
     },
     "node_modules/@shikijs/primitive": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/primitive/-/primitive-4.3.1.tgz",
       "integrity": "sha1-vy3lVZLcVeA27+mEvHXEV4BSGC0=",
       "dev": true,
       "license": "MIT",
@@ -2397,7 +2244,6 @@
     },
     "node_modules/@shikijs/themes": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/themes/-/themes-4.3.1.tgz",
       "integrity": "sha1-rpb23pocvckvbTUxYoENoDTwXlo=",
       "dev": true,
       "license": "MIT",
@@ -2410,7 +2256,6 @@
     },
     "node_modules/@shikijs/types": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/types/-/types-4.3.1.tgz",
       "integrity": "sha1-V9lQox9fSJtEeU+muaW17lB+C8M=",
       "dev": true,
       "license": "MIT",
@@ -2424,14 +2269,12 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha1-qQqzHQzB37VMZqaeUVv2JPp7IiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/node/-/node-4.3.3.tgz",
       "integrity": "sha1-OP8EMJ/wNuo1iae62QacROydOIM=",
       "dev": true,
       "license": "MIT",
@@ -2447,7 +2290,6 @@
     },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
       "integrity": "sha1-YmYQnQJc/LBPjkxYlUpvYwpBW38=",
       "dev": true,
       "license": "MIT",
@@ -2471,7 +2313,6 @@
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
       "integrity": "sha1-hI+TA0FV2veJIYUCjfsYFDv8fQc=",
       "cpu": [
         "arm64"
@@ -2488,7 +2329,6 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
       "integrity": "sha1-XHeeMsHDYb63UTb9jixif8uaWyg=",
       "cpu": [
         "arm64"
@@ -2505,7 +2345,6 @@
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
       "integrity": "sha1-uikv9S+jJkE59/54dHGc4KRmaHU=",
       "cpu": [
         "x64"
@@ -2522,7 +2361,6 @@
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
       "integrity": "sha1-B+WJSHuaY2I1pK3kjO/B+e7uxX8=",
       "cpu": [
         "x64"
@@ -2539,7 +2377,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
       "integrity": "sha1-DIq8Io2eGeAGXdtwfrpS4hhVs/8=",
       "cpu": [
         "arm"
@@ -2556,7 +2393,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
       "integrity": "sha1-UGfcev0V0rl63HepEXfcS+yNG4s=",
       "cpu": [
         "arm64"
@@ -2573,7 +2409,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
       "integrity": "sha1-Ka5fJ5vizmTbNocRmFtq2ORWLlc=",
       "cpu": [
         "arm64"
@@ -2590,7 +2425,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
       "integrity": "sha1-fWk7QPaYdXRLSZSBNZsif9OsOjw=",
       "cpu": [
         "x64"
@@ -2607,7 +2441,6 @@
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
       "integrity": "sha1-alXWZPR8X/mtP0a/Bf4H1BC4z9g=",
       "cpu": [
         "x64"
@@ -2624,7 +2457,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
       "integrity": "sha1-QIqbxiDmjxqvDf6jPae9O2X54u8=",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
@@ -2654,7 +2486,6 @@
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
       "integrity": "sha1-PVgrABgPpGgOC2yQvmn6X0ogkJI=",
       "cpu": [
         "arm64"
@@ -2671,7 +2502,6 @@
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
       "integrity": "sha1-zkxmP+87T95nYRpME5GGb4wKp5s=",
       "cpu": [
         "x64"
@@ -2688,7 +2518,6 @@
     },
     "node_modules/@tailwindcss/postcss": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
       "integrity": "sha1-3BTfZHftwWCH3xZjYX7iO8EEJhA=",
       "dev": true,
       "license": "MIT",
@@ -2702,7 +2531,6 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha1-AVy6np3UfOFNA9KoxdVHv7FpZl0=",
       "dev": true,
       "license": "MIT",
@@ -2713,14 +2541,12 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha1-zz8Oh2177hWpOrkluCv1cKOQSiQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
       "integrity": "sha1-hYqI6iDzT+ZREfAFpon6Hr9w3Bg=",
       "dev": true,
       "license": "MIT",
@@ -2730,7 +2556,6 @@
     },
     "node_modules/@types/hast": {
       "version": "3.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/hast/-/hast-3.0.5.tgz",
       "integrity": "sha1-SAIN5MDmNJL0yp20IGjBCPaLf48=",
       "dev": true,
       "license": "MIT",
@@ -2740,7 +2565,6 @@
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha1-fM9y7dLxqn3TQ34YDGQ3NYWATdY=",
       "dev": true,
       "license": "MIT",
@@ -2750,7 +2574,6 @@
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/nlcst/-/nlcst-2.0.3.tgz",
       "integrity": "sha1-McrTRuqrSKmopYRl09BeJTDdp2I=",
       "dev": true,
       "license": "MIT",
@@ -2760,7 +2583,6 @@
     },
     "node_modules/@types/node": {
       "version": "25.9.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-25.9.5.tgz",
       "integrity": "sha1-D+/Anm6C6UzeKRus9DUi6YnrAaQ=",
       "dev": true,
       "license": "MIT",
@@ -2770,14 +2592,12 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha1-rKqw+RnOaczmKcLU7S60rcG2wgw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha1-6bKAi08QlQSgPNqVglmHb2EBeZk=",
       "dev": true,
       "license": "MIT",
@@ -2788,14 +2608,12 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
       "integrity": "sha1-CUBB4aTLGYfwODNUISgayL45C8w=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@volar/kit": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/kit/-/kit-2.4.28.tgz",
       "integrity": "sha1-O7yVf6SZTHVXL+i28o0SkHq2KHc=",
       "dev": true,
       "license": "MIT",
@@ -2812,7 +2630,6 @@
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/language-core/-/language-core-2.4.28.tgz",
       "integrity": "sha1-wh82WpHB3/6L1yZP1JF3DI10/vM=",
       "dev": true,
       "license": "MIT",
@@ -2822,7 +2639,6 @@
     },
     "node_modules/@volar/language-server": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/language-server/-/language-server-2.4.28.tgz",
       "integrity": "sha1-Q/oowcO9zPpWqnmj+mpLaZb85HM=",
       "dev": true,
       "license": "MIT",
@@ -2840,7 +2656,6 @@
     },
     "node_modules/@volar/language-service": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/language-service/-/language-service-2.4.28.tgz",
       "integrity": "sha1-HKKY7O7B/qBZH12E3egZvl3XIJk=",
       "dev": true,
       "license": "MIT",
@@ -2853,14 +2668,12 @@
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/source-map/-/source-map-2.4.28.tgz",
       "integrity": "sha1-tAJU6MlhmeXx4Hlnd8WTxhetJw4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.28",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@volar/typescript/-/typescript-2.4.28.tgz",
       "integrity": "sha1-g/hjVuhOsQG4CBpEwQTy8s7YQR8=",
       "dev": true,
       "license": "MIT",
@@ -2872,7 +2685,6 @@
     },
     "node_modules/@vscode/emmet-helper": {
       "version": "2.11.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
       "integrity": "sha1-elPk/bFzKcwu2IA2kFx42BHSMdY=",
       "dev": true,
       "license": "MIT",
@@ -2886,21 +2698,18 @@
     },
     "node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
       "integrity": "sha1-WVSRULEz8u+sykj+nOHsBlmvI0I=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vscode/l10n": {
       "version": "0.0.18",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/l10n/-/l10n-0.0.18.tgz",
       "integrity": "sha1-kW06XpYNurR8HFb1iny1CHsTXJU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.18.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
       "dev": true,
       "license": "MIT",
@@ -2913,7 +2722,6 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "dev": true,
       "license": "MIT",
@@ -2930,7 +2738,6 @@
     },
     "node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha1-O2R2GyaLoLnmaPC0G6U/zgrXf8g=",
       "dev": true,
       "license": "MIT",
@@ -2945,7 +2752,6 @@
     },
     "node_modules/ajv-i18n": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
       "integrity": "sha1-1IdQumDig7Pe4x48IsjJ90EOMm8=",
       "dev": true,
       "license": "MIT",
@@ -2955,7 +2761,6 @@
     },
     "node_modules/am-i-vibing": {
       "version": "0.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/am-i-vibing/-/am-i-vibing-0.4.0.tgz",
       "integrity": "sha1-Tbp96V+brbPmGg8Fk/rEOEpKvH4=",
       "dev": true,
       "license": "MIT",
@@ -2968,7 +2773,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha1-YCFu6kZNhkWXzigyAAc4oFiWUME=",
       "dev": true,
       "license": "MIT",
@@ -2981,7 +2785,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
       "dev": true,
       "license": "MIT",
@@ -2994,7 +2797,6 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
       "dev": true,
       "license": "ISC",
@@ -3008,7 +2810,6 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
@@ -3021,14 +2822,12 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha1-k/gaQ0gOM6M48ZFjo9EKUMAdzVk=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3038,7 +2837,6 @@
     },
     "node_modules/astro": {
       "version": "7.1.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro/-/astro-7.1.6.tgz",
       "integrity": "sha1-MyQAvqA1TTxWo0+tL+b8hoSdwaI=",
       "dev": true,
       "license": "MIT",
@@ -3123,7 +2921,6 @@
     },
     "node_modules/astro-expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro-expressive-code/-/astro-expressive-code-0.44.1.tgz",
       "integrity": "sha1-3ar6xKhrRMmn7mW3WR46pT6lafE=",
       "dev": true,
       "license": "MIT",
@@ -3137,7 +2934,6 @@
     },
     "node_modules/astro-icon": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/astro-icon/-/astro-icon-1.1.5.tgz",
       "integrity": "sha1-XSSlXK7ViGUUpu3eXqfmI9/CL1k=",
       "dev": true,
       "license": "MIT",
@@ -3149,7 +2945,6 @@
     },
     "node_modules/astro/node_modules/magic-string": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-1.1.0.tgz",
       "integrity": "sha1-VKhHCqvyoEuXAXfybAMIyr6nSj8=",
       "dev": true,
       "license": "MIT",
@@ -3159,7 +2954,6 @@
     },
     "node_modules/autoprefixer": {
       "version": "10.5.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/autoprefixer/-/autoprefixer-10.5.4.tgz",
       "integrity": "sha1-O33YSLQVVRSpWtH2zlmIRL6glpc=",
       "dev": true,
       "funding": [
@@ -3196,7 +2990,6 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha1-KHaMdtDjz/IbxiqeLQtqwwBCoe4=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3206,7 +2999,6 @@
     },
     "node_modules/bail": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bail/-/bail-2.0.2.tgz",
       "integrity": "sha1-0m9c2P5db4MqMVF7n3w1YEC6bV0=",
       "dev": true,
       "license": "MIT",
@@ -3217,7 +3009,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
       "integrity": "sha1-ZbQSQ/KdLMp7XXLKbpuChd8e2XU=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3230,7 +3021,6 @@
     },
     "node_modules/bcp-47-match": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
       "integrity": "sha1-YDIm9uXTkUpYFAi+M7KKUxRLCdA=",
       "dev": true,
       "license": "MIT",
@@ -3241,14 +3031,12 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.28.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
       "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
@@ -3282,7 +3070,6 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true,
       "license": "MIT",
@@ -3292,7 +3079,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
       "integrity": "sha1-G8jlArcj+jk0Vd++3VzOwMKbt04=",
       "dev": true,
       "funding": [
@@ -3313,7 +3099,6 @@
     },
     "node_modules/ccount": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha1-F6O/gjAuCHDW2kOgExGovAKj7PU=",
       "dev": true,
       "license": "MIT",
@@ -3324,7 +3109,6 @@
     },
     "node_modules/character-entities-html4": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha1-HxrblAyXGksiujndymthjcblays=",
       "dev": true,
       "license": "MIT",
@@ -3335,7 +3119,6 @@
     },
     "node_modules/character-entities-legacy": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha1-dryDqQc4kB17wiOp6TdZ/dVgEls=",
       "dev": true,
       "license": "MIT",
@@ -3346,7 +3129,6 @@
     },
     "node_modules/cheerio": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cheerio/-/cheerio-1.2.0.tgz",
       "integrity": "sha1-8jt3fEkCHq10ddzzOQ01Naf4ltY=",
       "dev": true,
       "license": "MIT",
@@ -3372,7 +3154,6 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cheerio-select/-/cheerio-select-2.1.0.tgz",
       "integrity": "sha1-TYZzKGuBJsoqjkJ0DV48SISuIbQ=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3390,7 +3171,6 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha1-e+N6TAPJruHs/oYqSiOyxwwgXTA=",
       "dev": true,
       "license": "MIT",
@@ -3406,7 +3186,6 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha1-mFXmTs0kCpzEJnzopKpdJKHaFeQ=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3416,7 +3195,6 @@
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha1-fVTv+fVLRbYkAcJgMmlutZyL0Yw=",
       "dev": true,
       "funding": [
@@ -3432,7 +3210,6 @@
     },
     "node_modules/cliui": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cliui/-/cliui-9.0.1.tgz",
       "integrity": "sha1-b3iQ84b28feZU63B943sRvzC0pE=",
       "dev": true,
       "license": "ISC",
@@ -3447,7 +3224,6 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
@@ -3465,7 +3241,6 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha1-7tOXyf2L2IK/sY3qtxAgSaLzKZk=",
       "dev": true,
       "license": "MIT",
@@ -3475,7 +3250,6 @@
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha1-TonJRYrLYbyP7xn0UplzsjkoOe4=",
       "dev": true,
       "license": "MIT",
@@ -3486,7 +3260,6 @@
     },
     "node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-11.1.0.tgz",
       "integrity": "sha1-Yv3OdgBqaOXBqzMU3JLoAOuD2QY=",
       "dev": true,
       "license": "MIT",
@@ -3496,7 +3269,6 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
       "integrity": "sha1-8dNhrqkjaq1bkqD/W53xQi3TYP8=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -3506,14 +3278,12 @@
     },
     "node_modules/confbox": {
       "version": "0.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha1-WS575x+IKkqHTjyI8Kwe9vfaHOU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie/-/cookie-2.0.1.tgz",
       "integrity": "sha1-H8fpvd84+pVnzU11CCAIfNtdbpg=",
       "dev": true,
       "license": "MIT",
@@ -3527,14 +3297,12 @@
     },
     "node_modules/cookie-es": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cookie-es/-/cookie-es-1.2.3.tgz",
       "integrity": "sha1-Bso8X181MWhKIFlmajYRc/dKicg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/crossws": {
       "version": "0.3.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/crossws/-/crossws-0.3.5.tgz",
       "integrity": "sha1-2q0zHUQUjqZQAJi8hYhp86WrgaY=",
       "dev": true,
       "license": "MIT",
@@ -3544,7 +3312,6 @@
     },
     "node_modules/css-select": {
       "version": "5.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-select/-/css-select-5.2.2.tgz",
       "integrity": "sha1-Abbo0WNje7LdbJgspO1lhjaCeG4=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3561,7 +3328,6 @@
     },
     "node_modules/css-selector-parser": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-selector-parser/-/css-selector-parser-3.3.0.tgz",
       "integrity": "sha1-GjQiDXZ2LJKa6ZmT31pgch9QUII=",
       "dev": true,
       "funding": [
@@ -3578,7 +3344,6 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha1-hsrHARVhJysw5rHgQrps4EeqdRg=",
       "dev": true,
       "license": "MIT",
@@ -3592,7 +3357,6 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha1-zcyPm2l3cZ/fvR3nrsJKv3Vrneo=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3605,7 +3369,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true,
       "license": "MIT",
@@ -3618,7 +3381,6 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/csso/-/csso-5.0.5.tgz",
       "integrity": "sha1-+bf+bMasC32QeBuxbV6YdDA+LKY=",
       "dev": true,
       "license": "MIT",
@@ -3632,7 +3394,6 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/css-tree/-/css-tree-2.2.1.tgz",
       "integrity": "sha1-NhFdOC1gr9Jx43f5xfZ9Ar1IwDI=",
       "dev": true,
       "license": "MIT",
@@ -3647,14 +3408,12 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.0.28.tgz",
       "integrity": "sha1-XsSOe+8SBlRTkGnhrk3cgcpJDro=",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "dev": true,
       "license": "MIT",
@@ -3672,14 +3431,12 @@
     },
     "node_modules/defu": {
       "version": "6.1.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/defu/-/defu-6.1.7.tgz",
       "integrity": "sha1-clQ1Z8jp+X/xPOQCttvgmsWuTSM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dequal": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
       "dev": true,
       "license": "MIT",
@@ -3689,14 +3446,12 @@
     },
     "node_modules/destr": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/destr/-/destr-2.0.5.tgz",
       "integrity": "sha1-fREv8bkl+40gefrFvbSpCXO1H9s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
       "dev": true,
       "license": "Apache-2.0",
@@ -3706,14 +3461,12 @@
     },
     "node_modules/devalue": {
       "version": "5.8.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devalue/-/devalue-5.8.2.tgz",
       "integrity": "sha1-sJZE+gesseIf4fhB4MhOMosIQZY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha1-TbfCyk3G4Og0wwvnDJS7yXbccBg=",
       "dev": true,
       "license": "MIT",
@@ -3727,7 +3480,6 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diff/-/diff-8.0.4.tgz",
       "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -3737,7 +3489,6 @@
     },
     "node_modules/direction": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/direction/-/direction-2.0.1.tgz",
       "integrity": "sha1-cYAN08T6ECQGUCkF04ZuZb3ruYU=",
       "dev": true,
       "license": "MIT",
@@ -3751,7 +3502,6 @@
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha1-5BuALh7t+fbK4YPOXmIteJ19jlM=",
       "dev": true,
       "license": "MIT",
@@ -3766,7 +3516,6 @@
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha1-XEXo6GmVJiYzHXqrMm0B2vZdWJ0=",
       "dev": true,
       "funding": [
@@ -3779,7 +3528,6 @@
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha1-zDhff3UfHR/GUMITdIBCVFOMfTE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3795,7 +3543,6 @@
     },
     "node_modules/domutils": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/domutils/-/domutils-3.2.2.tgz",
       "integrity": "sha1-7b/itmiwwdl8JLrw8QYrEyIhvHg=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3810,7 +3557,6 @@
     },
     "node_modules/dset": {
       "version": "3.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dset/-/dset-3.1.4.tgz",
       "integrity": "sha1-+Or18CPwaKA20IzQfcn/t9AGUkg=",
       "dev": true,
       "license": "MIT",
@@ -3820,14 +3566,12 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.398",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
       "integrity": "sha1-nU2Xk0SsdihAKT4+rL6+00IoqhY=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emmet": {
       "version": "2.4.11",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emmet/-/emmet-2.4.11.tgz",
       "integrity": "sha1-szH1ct83olI2Dr7n3ERiyNLjL1w=",
       "dev": true,
       "license": "MIT",
@@ -3844,14 +3588,12 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha1-vz1uj3+P0ipl2XA0dbwBRzV6aw0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
       "integrity": "sha1-OW7JesIs5aA3ukSvGZKsnUanuBk=",
       "dev": true,
       "license": "MIT",
@@ -3865,7 +3607,6 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha1-c0TXEd6kDgt0q8LtSXeHQ8ztsIw=",
       "dev": true,
       "license": "MIT",
@@ -3875,7 +3616,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/enhanced-resolve/-/enhanced-resolve-5.24.4.tgz",
       "integrity": "sha1-7B8l7OEqN8wpl2K0EvpsWWLVIic=",
       "dev": true,
       "license": "MIT",
@@ -3889,7 +3629,6 @@
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-4.5.0.tgz",
       "integrity": "sha1-XSaOpecRPsdMTQM7eepaNaSI+0g=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3902,14 +3641,12 @@
     },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha1-W/LfBpmdu+XwBqX0ahH7n1t7ORs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
       "dev": true,
       "hasInstallScript": true,
@@ -3951,7 +3688,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha1-ARo/aYVroYnf+n3I/M6Z0qh5A+U=",
       "dev": true,
       "license": "MIT",
@@ -3961,7 +3697,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -3975,21 +3710,18 @@
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha1-UvAQF4wqTBF6d1fP6UKtt9LaTKw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha1-qG1mFwQzcS3egUcHrFK1JxzrH+s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/expressive-code/-/expressive-code-0.44.1.tgz",
       "integrity": "sha1-gaKP35qNRiJv8qNkoTtlQITGe2E=",
       "dev": true,
       "license": "MIT",
@@ -4002,21 +3734,18 @@
     },
     "node_modules/exsolve": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/exsolve/-/exsolve-1.1.1.tgz",
       "integrity": "sha1-wFVBglVFm27N5OWd4AYKPpe8dXI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/extend-shallow": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
       "dev": true,
       "license": "MIT",
@@ -4029,7 +3758,6 @@
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4050,21 +3778,18 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
       "integrity": "sha1-I6/g2mfXUsoHJ1OPHmlndZcozkk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-width/-/fast-string-width-3.0.2.tgz",
       "integrity": "sha1-FturtJHOVYW17LZ1tlwWXXFojus=",
       "dev": true,
       "license": "MIT",
@@ -4074,7 +3799,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
       "dev": true,
       "funding": [
@@ -4091,7 +3815,6 @@
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
       "integrity": "sha1-lelSoBRbzj9ZrVbhefhMSNQHKTU=",
       "dev": true,
       "license": "MIT",
@@ -4101,7 +3824,6 @@
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "license": "MIT",
@@ -4111,7 +3833,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha1-7Sq5Z6MxreYvGNB32uGSaE1Q01A=",
       "dev": true,
       "license": "MIT",
@@ -4129,7 +3850,6 @@
     },
     "node_modules/flattie": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/flattie/-/flattie-1.1.1.tgz",
       "integrity": "sha1-iBgiNXIxE2Z9NiF/7FU1knXW/j0=",
       "dev": true,
       "license": "MIT",
@@ -4139,7 +3859,6 @@
     },
     "node_modules/fontace": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fontace/-/fontace-0.4.1.tgz",
       "integrity": "sha1-3ip2zzYQiAFpAabyqPK9AWya6EQ=",
       "dev": true,
       "license": "MIT",
@@ -4149,7 +3868,6 @@
     },
     "node_modules/fontkitten": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fontkitten/-/fontkitten-1.0.3.tgz",
       "integrity": "sha1-u6/e3bseBUln8IRv3HV6zKuIu2g=",
       "dev": true,
       "license": "MIT",
@@ -4162,7 +3880,6 @@
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fraction.js/-/fraction.js-5.3.4.tgz",
       "integrity": "sha1-jA/MapkIJi307Rl0J73u9WPgaZo=",
       "dev": true,
       "license": "MIT",
@@ -4176,7 +3893,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
       "dev": true,
       "license": "MIT",
@@ -4190,7 +3906,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true,
       "license": "ISC",
@@ -4200,7 +3915,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha1-IWkA+R3xGossGYw+HZPWwDWndrk=",
       "dev": true,
       "license": "MIT",
@@ -4213,7 +3927,6 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
       "dev": true,
       "license": "MIT",
@@ -4229,7 +3942,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "5.0.0-beta.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
       "integrity": "sha1-SOHISRnRb9Ht/r0E6JWNqUKUXCU=",
       "dev": true,
       "license": "MIT",
@@ -4245,14 +3957,12 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha1-Us8vknmiHrbFndOFtBDwwK3ajxo=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/globals": {
       "version": "15.15.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/globals/-/globals-15.15.0.tgz",
       "integrity": "sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=",
       "dev": true,
       "license": "MIT",
@@ -4265,14 +3975,12 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha1-6JPAZIJd5z6h9ffYjHqfcnQoh5g=",
       "dev": true,
       "license": "MIT",
@@ -4288,7 +3996,6 @@
     },
     "node_modules/gray-matter/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "license": "MIT",
@@ -4298,7 +4005,6 @@
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
       "version": "3.15.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-3.15.0.tgz",
       "integrity": "sha1-WG5SFOr+Pok3VqQel5tQ2J0+Smc=",
       "dev": true,
       "license": "MIT",
@@ -4312,7 +4018,6 @@
     },
     "node_modules/h3": {
       "version": "1.15.11",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/h3/-/h3-1.15.11.tgz",
       "integrity": "sha1-gxF5/GtLwG3orRB356XH1jt5ZXc=",
       "dev": true,
       "license": "MIT",
@@ -4330,7 +4035,6 @@
     },
     "node_modules/hast-util-from-html": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
       "integrity": "sha1-SFx0eFNYvrgMS6Y0YpkxGsTEnII=",
       "dev": true,
       "license": "MIT",
@@ -4349,7 +4053,6 @@
     },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
       "integrity": "sha1-gwo1Ai//KMP+o2l6mML0zGuDWi4=",
       "dev": true,
       "license": "MIT",
@@ -4370,7 +4073,6 @@
     },
     "node_modules/hast-util-has-property": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-has-property/-/hast-util-has-property-3.0.0.tgz",
       "integrity": "sha1-TllePN24zlMOqS9vxBEagY2Of5M=",
       "dev": true,
       "license": "MIT",
@@ -4384,7 +4086,6 @@
     },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha1-bjGmUywhfltTOEjH5Sydk2nKCTI=",
       "dev": true,
       "license": "MIT",
@@ -4398,7 +4099,6 @@
     },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
       "integrity": "sha1-NSh5+obiVhYDYDfdiTH7XzTLSic=",
       "dev": true,
       "license": "MIT",
@@ -4412,7 +4112,6 @@
     },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-select/-/hast-util-select-6.0.4.tgz",
       "integrity": "sha1-HY9pZXpXRB0M4K3jWIeHTT5lowM=",
       "dev": true,
       "license": "MIT",
@@ -4440,7 +4139,6 @@
     },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
       "integrity": "sha1-zMZzpVu46Fd1sIrCg4D3LUcWcAU=",
       "dev": true,
       "license": "MIT",
@@ -4464,7 +4162,6 @@
     },
     "node_modules/hast-util-to-string": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
       "integrity": "sha1-pPFeaChJMm3SEclxKclLDD52Unw=",
       "dev": true,
       "license": "MIT",
@@ -4478,7 +4175,6 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
       "integrity": "sha1-V7Z2kx5xv5y4UkU2eElbMIC/rj4=",
       "dev": true,
       "license": "MIT",
@@ -4495,7 +4191,6 @@
     },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha1-d3jtnTyS3Z6MXI9kiknCH8UctiE=",
       "dev": true,
       "license": "MIT",
@@ -4509,7 +4204,6 @@
     },
     "node_modules/hastscript": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hastscript/-/hastscript-9.0.1.tgz",
       "integrity": "sha1-28hL72BR1ACENCwinEUc2dxWff8=",
       "dev": true,
       "license": "MIT",
@@ -4527,14 +4221,12 @@
     },
     "node_modules/html-escaper": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-escaper/-/html-escaper-3.0.3.tgz",
       "integrity": "sha1-TTNmdGUr6x3Lwp72trp/a+b9/tY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/html-void-elements/-/html-void-elements-3.0.0.tgz",
       "integrity": "sha1-/J29hK+edHJJA01NYmAt72UX8dc=",
       "dev": true,
       "license": "MIT",
@@ -4545,7 +4237,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/htmlparser2/-/htmlparser2-10.1.0.tgz",
       "integrity": "sha1-/j8uEsc7bkYtThA5XbnBEZ5NauQ=",
       "dev": true,
       "funding": [
@@ -4565,7 +4256,6 @@
     },
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-7.0.1.tgz",
       "integrity": "sha1-JuioiInbY0F9y5oeeaPxvJK1l2s=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -4578,14 +4268,12 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha1-IF9Ntk+FYrdqT/kjWqUnmDmgndU=",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
       "dev": true,
       "license": "MIT",
@@ -4598,7 +4286,6 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
       "integrity": "sha1-qmD/KqEFUGMPTAsR/SRCvs2zWm8=",
       "dev": true,
       "license": "MIT",
@@ -4608,7 +4295,6 @@
     },
     "node_modules/is-docker": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-docker/-/is-docker-4.0.0.tgz",
       "integrity": "sha1-aquHx3ow3f85xGCvNy7heVrueEg=",
       "dev": true,
       "license": "MIT",
@@ -4624,7 +4310,6 @@
     },
     "node_modules/is-extendable": {
       "version": "0.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true,
       "license": "MIT",
@@ -4634,7 +4319,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha1-1lAl7ew2V84DL9fbY8l4g+rtcfA=",
       "dev": true,
       "license": "MIT",
@@ -4647,7 +4331,6 @@
     },
     "node_modules/jiti": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha1-l0Io8vTKK8IYhaF5e0X+po6VDGQ=",
       "dev": true,
       "license": "MIT",
@@ -4657,7 +4340,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
       "dev": true,
       "funding": [
@@ -4680,21 +4362,18 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha1-8qUktPf9EePXkeVZl3rWC5i3mLQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true,
       "license": "MIT",
@@ -4704,7 +4383,6 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha1-lRBhAXlfcFDGxlDzUMaD/r3bF4A=",
       "dev": true,
       "license": "MIT",
@@ -4714,14 +4392,12 @@
     },
     "node_modules/kolorist": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/kolorist/-/kolorist-1.8.0.tgz",
       "integrity": "sha1-7d27vHiUvBMwLN90CvY3TUoEdDw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha1-uFqulkhtyxv0mnyFcSISc/Tx5Kk=",
       "dev": true,
       "license": "MPL-2.0",
@@ -4751,7 +4427,6 @@
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
       "integrity": "sha1-8DOIURbf79nG9UeHUj41FLYeGWg=",
       "cpu": [
         "arm64"
@@ -4772,7 +4447,6 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
       "integrity": "sha1-ULcYcbAcgZlYS2SeKSVH+up6+bU=",
       "cpu": [
         "arm64"
@@ -4793,7 +4467,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
       "integrity": "sha1-NfPpczLRMLnKGB4RtWje1q68bV4=",
       "cpu": [
         "x64"
@@ -4814,7 +4487,6 @@
     },
     "node_modules/lightningcss-freebsd-x64": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
       "integrity": "sha1-l3enZHK2Ttb/lDQq1kx7r9eUpXU=",
       "cpu": [
         "x64"
@@ -4835,7 +4507,6 @@
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
       "integrity": "sha1-E65lLhq3O5E117faFy9mbEEK1T0=",
       "cpu": [
         "arm"
@@ -4856,7 +4527,6 @@
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
       "integrity": "sha1-QXhYeVqUWS9oASOhsfnaig4e8zU=",
       "cpu": [
         "arm64"
@@ -4877,7 +4547,6 @@
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
       "integrity": "sha1-a+NmkugQtxgECAL9gJYjz/5zITM=",
       "cpu": [
         "arm64"
@@ -4898,7 +4567,6 @@
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
       "integrity": "sha1-C3gDr06yHP043Tn+Kru1PH3QkfY=",
       "cpu": [
         "x64"
@@ -4919,7 +4587,6 @@
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
       "integrity": "sha1-iNyLqGXd3bGsXvBLDxYYBEGMFjs=",
       "cpu": [
         "x64"
@@ -4940,7 +4607,6 @@
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
       "integrity": "sha1-TzC6P6XpJfW3n5RejMDRdsOxqzg=",
       "cpu": [
         "arm64"
@@ -4961,7 +4627,6 @@
     },
     "node_modules/lightningcss-win32-x64-msvc": {
       "version": "1.32.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
       "integrity": "sha1-FBqlYFZFBkkokCu0rwRfp9n0Igo=",
       "cpu": [
         "x64"
@@ -4982,7 +4647,6 @@
     },
     "node_modules/local-pkg": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/local-pkg/-/local-pkg-1.2.1.tgz",
       "integrity": "sha1-lig4k5mFHXjztQySNu3bAvDDGys=",
       "dev": true,
       "license": "MIT",
@@ -5000,7 +4664,6 @@
     },
     "node_modules/lru-cache": {
       "version": "11.5.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-11.5.2.tgz",
       "integrity": "sha1-AOFmZckMYg+6FKPDaHMql2ST92A=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5010,7 +4673,6 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha1-VnY+wJoPqAkd8nh5/ZTRkHjADZE=",
       "dev": true,
       "license": "MIT",
@@ -5020,7 +4682,6 @@
     },
     "node_modules/magicast": {
       "version": "0.5.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha1-GAD2523YsNvnJXQ4osM2rvq72QU=",
       "dev": true,
       "license": "MIT",
@@ -5032,7 +4693,6 @@
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
       "integrity": "sha1-1/+EykmaV+LAYK5nVIrZUOaJoFM=",
       "dev": true,
       "license": "MIT",
@@ -5054,14 +4714,12 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha1-43ucUIgLdTZsTUCsY9m7ys22Hw4=",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/micromark-util-character": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha1-L5h4MaQNTFEKwmHomFLE6XA8zaY=",
       "dev": true,
       "funding": [
@@ -5082,7 +4740,6 @@
     },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha1-DVHRwJVVHPqsNoMmljz1XxX1QLg=",
       "dev": true,
       "funding": [
@@ -5099,7 +4756,6 @@
     },
     "node_modules/micromark-util-sanitize-uri": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha1-q4l4m4GKWHUrc9a1UjhiG3+qj9c=",
       "dev": true,
       "funding": [
@@ -5121,7 +4777,6 @@
     },
     "node_modules/micromark-util-symbol": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha1-5dpJTo6ysHGg0I+zT2zv7GwKGbg=",
       "dev": true,
       "funding": [
@@ -5138,7 +4793,6 @@
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha1-8AIl9fWg68MlT5bDa2YFxLOTkI4=",
       "dev": true,
       "funding": [
@@ -5155,7 +4809,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5165,7 +4818,6 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha1-atdsOo8QInybUdHJrI4wsn9aJRw=",
       "dev": true,
       "license": "MIT",
@@ -5178,7 +4830,6 @@
     },
     "node_modules/mlly": {
       "version": "1.8.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mlly/-/mlly-1.8.2.tgz",
       "integrity": "sha1-5/eRmoLROxdEBWExFySaP0SdeLs=",
       "dev": true,
       "license": "MIT",
@@ -5191,14 +4842,12 @@
     },
     "node_modules/mlly/node_modules/confbox": {
       "version": "0.1.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha1-gg1z07PILZvZEGUsXU1Znvj/iwY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mlly/node_modules/pkg-types": {
       "version": "1.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha1-vXzHCIEZJ3fu9TJsGd60bokJF98=",
       "dev": true,
       "license": "MIT",
@@ -5210,7 +4859,6 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mrmime/-/mrmime-2.0.1.tgz",
       "integrity": "sha1-vD6H95h4U6VMmFDusfEHjNRK3dw=",
       "dev": true,
       "license": "MIT",
@@ -5220,21 +4868,18 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha1-OzZr1Dsy+AncIGWVNN0w58ig0yg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nanoid/-/nanoid-3.3.16.tgz",
       "integrity": "sha1-oE2OxLHxAAnS1TOUeu/kKTc3gWw=",
       "dev": true,
       "funding": [
@@ -5253,7 +4898,6 @@
     },
     "node_modules/neotraverse": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/neotraverse/-/neotraverse-1.0.1.tgz",
       "integrity": "sha1-fIm0P2UE74WSjHGPV4xoYhV20ZQ=",
       "dev": true,
       "license": "MIT",
@@ -5263,7 +4907,6 @@
     },
     "node_modules/nlcst-to-string": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
       "integrity": "sha1-BVEehGHr+0FZUusLfpoafUBHG9Q=",
       "dev": true,
       "license": "MIT",
@@ -5277,21 +4920,18 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha1-nQnKYwZsxIQjIR7UyvXXAHXXanE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-mock-http": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-mock-http/-/node-mock-http-1.0.5.tgz",
       "integrity": "sha1-SXvC890gjm4/fAbLtKNCX4mf6Bg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.51",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-releases/-/node-releases-2.0.51.tgz",
       "integrity": "sha1-zcCEM1d/WzKtAWlEgXJuIu61Su8=",
       "dev": true,
       "license": "MIT",
@@ -5301,7 +4941,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true,
       "license": "MIT",
@@ -5311,7 +4950,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nth-check/-/nth-check-2.1.1.tgz",
       "integrity": "sha1-yeq0KO/842zWuSySS9sADvHx7R0=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5324,7 +4962,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/obug/-/obug-2.1.4.tgz",
       "integrity": "sha1-kJDYpUilIlF5FdKqaq6QcZesbPg=",
       "dev": true,
       "funding": [
@@ -5338,7 +4975,6 @@
     },
     "node_modules/ofetch": {
       "version": "1.5.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ofetch/-/ofetch-1.5.1.tgz",
       "integrity": "sha1-XEPMVuAzmLJzAUlXBgNEJUUFxcc=",
       "dev": true,
       "license": "MIT",
@@ -5350,14 +4986,12 @@
     },
     "node_modules/ohash": {
       "version": "2.0.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha1-YLEejP9iyp3uiNE3R6W6oUX1kAs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "license": "ISC",
@@ -5367,14 +5001,12 @@
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
       "integrity": "sha1-4nykRvf88JaWYqOrm09DF21isTk=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
       "version": "4.3.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
       "integrity": "sha1-Q+ZAKAJBsNaHoxTnpkHUdkB6HE0=",
       "dev": true,
       "license": "MIT",
@@ -5386,7 +5018,6 @@
     },
     "node_modules/p-limit": {
       "version": "7.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-7.3.1.tgz",
       "integrity": "sha1-3tSMv6ELFhqZKBICYfqCyaKC6z8=",
       "dev": true,
       "license": "MIT",
@@ -5402,7 +5033,6 @@
     },
     "node_modules/p-queue": {
       "version": "9.3.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-queue/-/p-queue-9.3.3.tgz",
       "integrity": "sha1-xeUox+s2G3uo61qUBpAvfy51/I8=",
       "dev": true,
       "license": "MIT",
@@ -5419,7 +5049,6 @@
     },
     "node_modules/p-timeout": {
       "version": "7.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-timeout/-/p-timeout-7.0.1.tgz",
       "integrity": "sha1-lWgKaqaTxTDxSsM3uL0y1Oxq5PA=",
       "dev": true,
       "license": "MIT",
@@ -5432,14 +5061,12 @@
     },
     "node_modules/package-manager-detector": {
       "version": "1.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
       "integrity": "sha1-cMmixL0aUT3NbK0Aap/OvsIqElM=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha1-1+Ik+nI5nHoXUJn0X8KtAksF7AU=",
       "dev": true,
       "license": "MIT",
@@ -5452,7 +5079,6 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
       "integrity": "sha1-tagGVI7Yk6Q+JMy0L7t4BpMR6Bs=",
       "dev": true,
       "license": "MIT",
@@ -5466,7 +5092,6 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
       "integrity": "sha1-18IOrcN5aNJy4sAmYP/5LdJ+YOE=",
       "dev": true,
       "license": "MIT",
@@ -5479,7 +5104,6 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/entities/-/entities-6.0.1.tgz",
       "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
       "dev": true,
       "license": "BSD-2-Clause",
@@ -5492,42 +5116,36 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha1-2YRUqcN1PVeQhg8W9ohnueRr4f0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha1-PsvsVUIWhbcKnahyss/z4cvtFxY=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/piccolore": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/piccolore/-/piccolore-0.1.3.tgz",
       "integrity": "sha1-7zP2GA5qN7Nf4SpFdlqQAXHPrtw=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha1-UepXoX2G9gX4EDlZX7xA7QalX6s=",
       "dev": true,
       "license": "MIT",
@@ -5540,7 +5158,6 @@
     },
     "node_modules/pkg-types": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha1-+iftCUDvz0C7pFOw5cq0Ehew1EI=",
       "dev": true,
       "license": "MIT",
@@ -5552,7 +5169,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.25",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha1-UBKlmOqqiX8hu+hVO+PLe9K9eMs=",
       "dev": true,
       "funding": [
@@ -5581,7 +5197,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha1-TC0iq18gucth4sXFkVlQeE0GgTE=",
       "dev": true,
       "funding": [
@@ -5607,7 +5222,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
       "integrity": "sha1-/exMqA9Xgb0hbKm/iaKg/M//pfA=",
       "dev": true,
       "license": "MIT",
@@ -5621,14 +5235,12 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha1-cjwJkgg2um0+WvAZ+SvAlxwC5RQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.9.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prettier/-/prettier-3.9.6.tgz",
       "integrity": "sha1-s+pRRlFdQPxT8YqmP3Tfqx4Q2/Y=",
       "dev": true,
       "license": "MIT",
@@ -5644,7 +5256,6 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/prismjs/-/prismjs-1.30.0.tgz",
       "integrity": "sha1-2XCZadnU4WQD9vNIxjVTsZ8Jdak=",
       "dev": true,
       "license": "MIT",
@@ -5654,7 +5265,6 @@
     },
     "node_modules/process-ancestry": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/process-ancestry/-/process-ancestry-0.1.0.tgz",
       "integrity": "sha1-BqGLsGxBPYJ1AhkEWPx2BO5rPe0=",
       "dev": true,
       "license": "MIT",
@@ -5664,7 +5274,6 @@
     },
     "node_modules/property-information": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/property-information/-/property-information-7.2.0.tgz",
       "integrity": "sha1-CAmzQmTplcC/zTInAooeNSEK+Ao=",
       "dev": true,
       "license": "MIT",
@@ -5675,7 +5284,6 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pump/-/pump-3.0.4.tgz",
       "integrity": "sha1-HzE0MFJ/qLkFYi69Iv4UROdXqzw=",
       "dev": true,
       "license": "MIT",
@@ -5686,7 +5294,6 @@
     },
     "node_modules/quansync": {
       "version": "0.2.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/quansync/-/quansync-0.2.11.tgz",
       "integrity": "sha1-+cOt2i4ScuT4zz8UV7BMvbTuaSo=",
       "dev": true,
       "funding": [
@@ -5703,14 +5310,12 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha1-/SfSrziWxr9Lzfq2Qnxpwq/GnsA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha1-64WAFDX78qfuWPGeCSGwaPxplI0=",
       "dev": true,
       "license": "MIT",
@@ -5724,7 +5329,6 @@
     },
     "node_modules/regex": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex/-/regex-6.1.0.tgz",
       "integrity": "sha1-186Y+O4y2nSXwT9mAfyivEpqeAM=",
       "dev": true,
       "license": "MIT",
@@ -5734,7 +5338,6 @@
     },
     "node_modules/regex-recursion": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex-recursion/-/regex-recursion-6.0.2.tgz",
       "integrity": "sha1-oLGXenTIfwczd7k42+36supYKzM=",
       "dev": true,
       "license": "MIT",
@@ -5744,14 +5347,12 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha1-hxY1EqFdzikIzweciWDVFY/0MoA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rehype-expressive-code": {
       "version": "0.44.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rehype-expressive-code/-/rehype-expressive-code-0.44.1.tgz",
       "integrity": "sha1-puKJiFR7LTBppC69ymlOAhhEzmA=",
       "dev": true,
       "license": "MIT",
@@ -5761,14 +5362,12 @@
     },
     "node_modules/request-light": {
       "version": "0.7.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/request-light/-/request-light-0.7.0.tgz",
       "integrity": "sha1-iFYouy+AQMJkAevyWOxRxK6YrCo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
       "dev": true,
       "license": "MIT",
@@ -5778,7 +5377,6 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha1-YWs9wsVwVrVYjDHN9LPWTbEzcg8=",
       "dev": true,
       "license": "MIT",
@@ -5788,7 +5386,6 @@
     },
     "node_modules/retext-smartypants": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
       "integrity": "sha1-ToUsKXTPLPolPu7EJ8l+/EO10Vg=",
       "dev": true,
       "license": "MIT",
@@ -5804,7 +5401,6 @@
     },
     "node_modules/rolldown": {
       "version": "1.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha1-M5quJQhENR/FW3TiZS0+vW+6OJ0=",
       "dev": true,
       "license": "MIT",
@@ -5838,14 +5434,12 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/satteri": {
       "version": "0.9.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/satteri/-/satteri-0.9.5.tgz",
       "integrity": "sha1-J8h+v3YIuxYfTLUQi5YchDjBiLc=",
       "dev": true,
       "license": "MIT",
@@ -5869,7 +5463,6 @@
     },
     "node_modules/sax": {
       "version": "1.6.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sax/-/sax-1.6.1.tgz",
       "integrity": "sha1-TCPPYIwLaTq1S0tYiOks/pd7mEM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -5879,7 +5472,6 @@
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha1-6QQZU1BngOwB1Z8pKhnHuFC4QWc=",
       "dev": true,
       "license": "MIT",
@@ -5893,7 +5485,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
       "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
       "dev": true,
       "license": "ISC",
@@ -5906,7 +5497,6 @@
     },
     "node_modules/sharp": {
       "version": "0.35.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sharp/-/sharp-0.35.3.tgz",
       "integrity": "sha1-Qe0hpGQGvhY+rNC+ezZLQvzyiF8=",
       "dev": true,
       "license": "Apache-2.0",
@@ -5957,7 +5547,6 @@
     },
     "node_modules/shiki": {
       "version": "4.3.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shiki/-/shiki-4.3.1.tgz",
       "integrity": "sha1-Cmq/ptAGRmtemy9u7Hnm4QWpPAA=",
       "dev": true,
       "license": "MIT",
@@ -5977,14 +5566,12 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha1-E01oEpd1ZDfMBcoBNw06elcQde0=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/smol-toml": {
       "version": "1.7.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/smol-toml/-/smol-toml-1.7.1.tgz",
       "integrity": "sha1-uj4o0uQ0iHSoJP2OHXP+xhjLdjs=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -5997,7 +5584,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha1-HOVlD93YerwJnto33P8CTCZnrkY=",
       "dev": true,
       "license": "BSD-3-Clause",
@@ -6007,7 +5593,6 @@
     },
     "node_modules/space-separated-tokens": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha1-Hs2dI1CjhEVyw/SjErzrAYNIhZ8=",
       "dev": true,
       "license": "MIT",
@@ -6018,14 +5603,12 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/string-width": {
       "version": "8.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-8.2.2.tgz",
       "integrity": "sha1-cxBRZJPfV1dC/pivb66H2F1e0Kw=",
       "dev": true,
       "license": "MIT",
@@ -6042,7 +5625,6 @@
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha1-s7ee9fJ3zErHPK6wI2xbqTmzpPM=",
       "dev": true,
       "license": "MIT",
@@ -6057,7 +5639,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha1-0iomlSKDamJ6+NBLXD/Sx/o+MuM=",
       "dev": true,
       "license": "MIT",
@@ -6073,7 +5654,6 @@
     },
     "node_modules/strip-bom-string": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
       "dev": true,
       "license": "MIT",
@@ -6083,7 +5663,6 @@
     },
     "node_modules/svgo": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/svgo/-/svgo-4.0.2.tgz",
       "integrity": "sha1-piJG8KnWccAxTQTzzBX3ixvQZn8=",
       "dev": true,
       "license": "MIT",
@@ -6109,14 +5688,12 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha1-wAaGFhHCE8GHeJOrWyPaoWviu1U=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha1-XafJmSxGA4IhJnmFqyhCGoh58WA=",
       "dev": true,
       "license": "MIT",
@@ -6130,7 +5707,6 @@
     },
     "node_modules/tar": {
       "version": "7.5.22",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.22.tgz",
       "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -6147,14 +5723,12 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha1-EicVSUkToYBRZqr3yTRnkz7qJsQ=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
       "version": "0.1.15",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyclip/-/tinyclip-0.1.15.tgz",
       "integrity": "sha1-2zXqor1f5iez7y6jjYsEB/K8Le8=",
       "dev": true,
       "license": "MIT",
@@ -6164,7 +5738,6 @@
     },
     "node_modules/tinyexec": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyexec/-/tinyexec-1.2.4.tgz",
       "integrity": "sha1-rkW7Lt69qUxw9OqJfg8SQ+Rw23E=",
       "dev": true,
       "license": "MIT",
@@ -6174,7 +5747,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "dev": true,
       "license": "MIT",
@@ -6191,7 +5763,6 @@
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha1-2ALjMqB9+GHEiALAQyEBexvYczg=",
       "dev": true,
       "license": "MIT",
@@ -6202,7 +5773,6 @@
     },
     "node_modules/trough": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/trough/-/trough-2.2.0.tgz",
       "integrity": "sha1-lKYL1r03XBUsHfkRpLEdWwJW9Q8=",
       "dev": true,
       "license": "MIT",
@@ -6213,7 +5783,6 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "dev": true,
       "license": "0BSD",
@@ -6221,14 +5790,12 @@
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typesafe-path/-/typesafe-path-0.2.2.tgz",
       "integrity": "sha1-kaQ2aBsvUUutsRQGG2peXCuJQ7E=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha1-kCUdwAeRbpcnhsuU100VsYVXfSE=",
       "dev": true,
       "license": "Apache-2.0",
@@ -6242,7 +5809,6 @@
     },
     "node_modules/typescript-auto-import-cache": {
       "version": "0.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
       "integrity": "sha1-efA3XW+hbTETPPNdNgJbWCN8ScE=",
       "dev": true,
       "license": "MIT",
@@ -6252,28 +5818,24 @@
     },
     "node_modules/ufo": {
       "version": "1.6.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha1-eo+4dfzGOC0sfQs2knOLBQCpJGc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ultrahtml/-/ultrahtml-1.7.0.tgz",
       "integrity": "sha1-jn1ZfjOKSB6oKFKpul6AIcVK7RA=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha1-4SiNYJIm8tAtjWnuhh+iDYNI7ys=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.29.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-7.29.0.tgz",
       "integrity": "sha1-rg9vYuBuBXqcu3srX94rt095G48=",
       "dev": true,
       "license": "MIT",
@@ -6283,14 +5845,12 @@
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha1-YSdbSF1/1OnSacfPBOwoc8nMD5E=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unified/-/unified-11.0.5.tgz",
       "integrity": "sha1-9mZ3YQpcCp7pDKsrjU1mA3Am2eE=",
       "dev": true,
       "license": "MIT",
@@ -6310,7 +5870,6 @@
     },
     "node_modules/unifont": {
       "version": "0.7.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unifont/-/unifont-0.7.4.tgz",
       "integrity": "sha1-YravaPS2Ato0n8ENySUl/5O/8yk=",
       "dev": true,
       "license": "MIT",
@@ -6322,7 +5881,6 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
       "integrity": "sha1-P8zBsIa1bzTIt5jh/5C1xURo6JY=",
       "dev": true,
       "license": "MIT",
@@ -6337,7 +5895,6 @@
     },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha1-0KP4by3Q23rNfYwkeAgLXGf5xqk=",
       "dev": true,
       "license": "MIT",
@@ -6351,7 +5908,6 @@
     },
     "node_modules/unist-util-position": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha1-Z48gq1yhIHqX1+qKOINzyc+Ja+Q=",
       "dev": true,
       "license": "MIT",
@@ -6365,7 +5921,6 @@
     },
     "node_modules/unist-util-stringify-position": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha1-RJxuIaiA4IVb9aq63rOnQDFKusI=",
       "dev": true,
       "license": "MIT",
@@ -6379,7 +5934,6 @@
     },
     "node_modules/unist-util-visit": {
       "version": "5.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha1-mioosKp2oV4NpwoIpYY6LwYOJGg=",
       "dev": true,
       "license": "MIT",
@@ -6395,7 +5949,6 @@
     },
     "node_modules/unist-util-visit-parents": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha1-d333+5hlLOFrS3zZmdChpA76OgI=",
       "dev": true,
       "license": "MIT",
@@ -6410,7 +5963,6 @@
     },
     "node_modules/unstorage": {
       "version": "1.17.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unstorage/-/unstorage-1.17.5.tgz",
       "integrity": "sha1-52yC/cHSwEyw4sCh3giqCLIlP1E=",
       "dev": true,
       "license": "MIT",
@@ -6507,7 +6059,6 @@
     },
     "node_modules/unstorage/node_modules/chokidar": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha1-lJwSapI4qAeSvpoCZZNPCYrzaaU=",
       "dev": true,
       "license": "MIT",
@@ -6523,7 +6074,6 @@
     },
     "node_modules/unstorage/node_modules/readdirp": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha1-+/H3GnJ4kdaFuxeG+bp0CE9uL5E=",
       "dev": true,
       "license": "MIT",
@@ -6537,7 +6087,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
       "dev": true,
       "funding": [
@@ -6568,7 +6117,6 @@
     },
     "node_modules/url-extras": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/url-extras/-/url-extras-0.1.0.tgz",
       "integrity": "sha1-kFxfPR0tYoTZcxyHYlu/pwL9ra0=",
       "dev": true,
       "license": "MIT",
@@ -6581,14 +6129,12 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vfile": {
       "version": "6.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha1-NlKrHEllMYUr9VprrFevmB68OKs=",
       "dev": true,
       "license": "MIT",
@@ -6603,7 +6149,6 @@
     },
     "node_modules/vfile-location": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-location/-/vfile-location-5.0.3.tgz",
       "integrity": "sha1-y56s0g8rZCbRlFHg6vo9CoRiJcM=",
       "dev": true,
       "license": "MIT",
@@ -6618,7 +6163,6 @@
     },
     "node_modules/vfile-message": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha1-h7RN3de3DwZBwuPtCGS6c+LqjfQ=",
       "dev": true,
       "license": "MIT",
@@ -6633,7 +6177,6 @@
     },
     "node_modules/vite": {
       "version": "8.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vite/-/vite-8.1.5.tgz",
       "integrity": "sha1-zP/OPuSHsYhiI7JOuye5FnSCfTA=",
       "dev": true,
       "license": "MIT",
@@ -6711,7 +6254,6 @@
     },
     "node_modules/vitefu": {
       "version": "1.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vitefu/-/vitefu-1.1.3.tgz",
       "integrity": "sha1-WbmIWxwgCFYxnX6c6w6ZoGVDAAk=",
       "dev": true,
       "license": "MIT",
@@ -6731,7 +6273,6 @@
     },
     "node_modules/volar-service-css": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-css/-/volar-service-css-0.0.71.tgz",
       "integrity": "sha1-P5t7RMm7t+OV+58nkO5UQPgrLHk=",
       "dev": true,
       "license": "MIT",
@@ -6751,7 +6292,6 @@
     },
     "node_modules/volar-service-emmet": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
       "integrity": "sha1-IRkR6CT6ATGailWxTNVf55Dyvtc=",
       "dev": true,
       "license": "MIT",
@@ -6772,7 +6312,6 @@
     },
     "node_modules/volar-service-html": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-html/-/volar-service-html-0.0.71.tgz",
       "integrity": "sha1-x2cl8EyFMkWnpmgU8ENUpwUjApc=",
       "dev": true,
       "license": "MIT",
@@ -6792,7 +6331,6 @@
     },
     "node_modules/volar-service-prettier": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
       "integrity": "sha1-mIw5zJN/bHTF8N9ArpGry+U5mTg=",
       "dev": true,
       "license": "MIT",
@@ -6814,7 +6352,6 @@
     },
     "node_modules/volar-service-typescript": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
       "integrity": "sha1-4iVTSY46Mk04hlPn32McZ+Fg/J0=",
       "dev": true,
       "license": "MIT",
@@ -6837,7 +6374,6 @@
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
       "integrity": "sha1-2GwbONHv2RBVq1665rxy+d9wsfQ=",
       "dev": true,
       "license": "MIT",
@@ -6855,7 +6391,6 @@
     },
     "node_modules/volar-service-yaml": {
       "version": "0.0.71",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
       "integrity": "sha1-dIyKhgORqavi+j57axE74KaJE2Q=",
       "dev": true,
       "license": "MIT",
@@ -6874,7 +6409,6 @@
     },
     "node_modules/vscode-css-languageservice": {
       "version": "6.3.10",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
       "integrity": "sha1-JCNlrD/y62n3fKdQOk5pQTUYAwI=",
       "dev": true,
       "license": "MIT",
@@ -6887,14 +6421,12 @@
     },
     "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha1-MnNnbwzy6rQLP0TQhay7fwijnYo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-html-languageservice": {
       "version": "5.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
       "integrity": "sha1-MvUyYdpdD61PachdwA3mZJ4hC9E=",
       "dev": true,
       "license": "MIT",
@@ -6907,7 +6439,6 @@
     },
     "node_modules/vscode-json-languageservice": {
       "version": "4.1.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
       "integrity": "sha1-OXo5I41Jbj4IpUSouT3yzRM0fQw=",
       "dev": true,
       "license": "MIT",
@@ -6924,7 +6455,6 @@
     },
     "node_modules/vscode-jsonrpc": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
       "integrity": "sha1-XoSKSt3wBLYzcVb3hYoAbgg4tPU=",
       "dev": true,
       "license": "MIT",
@@ -6934,7 +6464,6 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "9.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
       "integrity": "sha1-UArvggl+uU35DQCGeLC2tfR0AVs=",
       "dev": true,
       "license": "MIT",
@@ -6947,7 +6476,6 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.18.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
       "integrity": "sha1-5/s25royvHumIiV623imEmJz3cU=",
       "dev": true,
       "license": "MIT",
@@ -6958,21 +6486,18 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
       "integrity": "sha1-RX7gQnGrOJmKCTxowjQvU/bkpjE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.18.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
       "integrity": "sha1-EyMhIpYEg2urcQyXSH5s2vub17s=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
       "integrity": "sha1-9D36NftR52PRfNlNzKDJRY81q/k=",
       "dev": true,
       "license": "MIT",
@@ -6982,7 +6507,6 @@
     },
     "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
       "integrity": "sha1-hkqLjzkINVcvThO9n4MT0OOsS+o=",
       "dev": true,
       "license": "MIT",
@@ -6993,28 +6517,24 @@
     },
     "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha1-MnNnbwzy6rQLP0TQhay7fwijnYo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-nls": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-nls/-/vscode-nls-5.2.0.tgz",
       "integrity": "sha1-PLaJPdm9aVJE2KAkvfdG7qZlzD8=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha1-3QnsWmaji1w//8d0AVcTSW0U4Jw=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/web-namespaces/-/web-namespaces-2.0.1.tgz",
       "integrity": "sha1-EBD/fGUOzLJZLOvur5obJT/UBpI=",
       "dev": true,
       "license": "MIT",
@@ -7025,7 +6545,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha1-0PTvdpkF1CbhaI8+NDgambYLduU=",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
@@ -7039,7 +6558,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha1-vBv5SphdxQOI1UqSWKxAXDyi/Ao=",
       "dev": true,
       "license": "MIT",
@@ -7049,7 +6567,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha1-lWgy3qlJQwbm0gnrhxZDu4c9fJg=",
       "dev": true,
       "license": "MIT",
@@ -7067,7 +6584,6 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
       "dev": true,
       "license": "MIT",
@@ -7085,21 +6601,18 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha1-/+fwuYIgpK+sFx4/ubbR+HcfAV4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
       "dev": true,
       "license": "ISC",
@@ -7109,7 +6622,6 @@
     },
     "node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha1-AOLeRDY57Q14/YfeDSdGn7z/tTM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
@@ -7119,7 +6631,6 @@
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "dev": true,
       "license": "ISC",
@@ -7135,7 +6646,6 @@
     },
     "node_modules/yaml-language-server": {
       "version": "1.23.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
       "integrity": "sha1-hSrDGSQ35V1sMafDDZed2X4t2cY=",
       "dev": true,
       "license": "MIT",
@@ -7159,14 +6669,12 @@
     },
     "node_modules/yaml-language-server/node_modules/request-light": {
       "version": "0.5.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/request-light/-/request-light-0.5.8.tgz",
       "integrity": "sha1-i/c6ByQrnntgH6wvpdwioJSrzCc=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yaml-language-server/node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha1-oNa9Lvs90DxZNwIjcBg05gQJvX0=",
       "dev": true,
       "license": "ISC",
@@ -7182,7 +6690,6 @@
     },
     "node_modules/yargs": {
       "version": "18.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs/-/yargs-18.1.0.tgz",
       "integrity": "sha1-zX6YxwPvUWlbu/Bi7VjyjpQpG1Y=",
       "dev": true,
       "license": "MIT",
@@ -7200,7 +6707,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yargs-parser/-/yargs-parser-22.0.0.tgz",
       "integrity": "sha1-h7gglAUbBWdxc0bs0A/RSASzV8g=",
       "dev": true,
       "license": "ISC",
@@ -7210,7 +6716,6 @@
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "license": "MIT",
@@ -7221,7 +6726,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yocto-queue/-/yocto-queue-1.2.2.tgz",
       "integrity": "sha1-PgnJXT8aqJpYwRTJkiPt9jkVLAA=",
       "dev": true,
       "license": "MIT",
@@ -7234,7 +6738,6 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
       "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
       "dev": true,
       "license": "MIT",
@@ -7244,7 +6747,6 @@
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha1-yCfUsKy3b8PmhaTG7CkC1RBw6dc=",
       "dev": true,
       "license": "MIT",


### PR DESCRIPTION
## Summary

The landing page lockfile recorded Azure Artifacts proxy URLs in registry dependency `resolved` fields. This change adds `omit-lockfile-registry-resolved=true` to the existing project `.npmrc` and regenerates the lockfile with npm 12.0.2.

The existing `packagefeedproxy.microsoft.io` registry setting remains unchanged. Dependency versions, integrity hashes, and `lockfileVersion` are unchanged.

## Validation

- `npx --yes npm@12.0.2 config get omit-lockfile-registry-resolved`
- `npx --yes npm@12.0.2 install --package-lock-only --ignore-scripts`
- Repeated lockfile generation and confirmed a clean result
- `npx --yes npm@12.0.2 ci --ignore-scripts`
- `npx --yes npm@12.0.2 run build`

The build completed with no Astro errors or warnings. npm reported the repository's existing audit findings but completed successfully.

npm config reference: https://docs.npmjs.com/cli/v8/using-npm/config#omit-lockfile-registry-resolved
